### PR TITLE
Allow to create external account using BankAccount struct

### DIFF
--- a/test/stripe/connect/external_account_test.exs
+++ b/test/stripe/connect/external_account_test.exs
@@ -2,11 +2,32 @@ defmodule Stripe.ExternalAccountTest do
   use Stripe.StripeCase, async: true
 
   describe "create/2" do
-    test "creates a bank account for an account" do
+    test "creates a bank account for an account with token" do
       {:ok, _} =
         Stripe.ExternalAccount.create(%{account: "acct_123", token: "tok_stripetestbank"})
 
-      assert_stripe_requested(:post, "/v1/accounts/acct_123/external_accounts")
+      assert_stripe_requested(:post, "/v1/accounts/acct_123/external_accounts", body: %{
+        external_account: "tok_stripetestbank"
+      })
+    end
+
+    test "creates a bank account for an account with object" do
+      {:ok, _} =
+        Stripe.ExternalAccount.create(%{account: "acct_123", external_account: %{
+          object: "bank_account",
+          account_number: "1234567890",
+          currency: "USD",
+          country: "US"
+        }})
+
+      assert_stripe_requested(:post, "/v1/accounts/acct_123/external_accounts", body: %{
+        external_account: %{
+          object: "bank_account",
+          account_number: "1234567890",
+          currency: "USD",
+          country: "US"
+        }
+      })
     end
 
     test "creates a card for an account" do


### PR DESCRIPTION
https://stripe.com/docs/api/external_account_bank_accounts/create?lang=curl

According to the doc the `external_account` param can be as well a BankAccount hash of values, which is implemented by this PR

It seems that `stripe-mock` doesn't accept a map of values yet on this endpoint, whereas the test/live API does - so the test I added is failing for the moment.
I opened an issue on the stripe-mock repo to let them now:
https://github.com/stripe/stripe-mock/issues/187