### PR TITLE
Fix type spec of line_items on Checkout Session

### DIFF
--- a/lib/stripe/checkout/session.ex
+++ b/lib/stripe/checkout/session.ex
@@ -155,7 +155,7 @@ defmodule Stripe.Session do
           }
         }
 
-  @type line_item_data :: %{
+  @type line_item_create :: %{
           optional(:id) => Stripe.id(),
           optional(:object) => String.t(),
           optional(:quantity) => integer(),
@@ -173,10 +173,14 @@ defmodule Stripe.Session do
         }
 
   @type line_item :: %{
-          optional(:object) => String.t(),
-          optional(:data) => line_item_data(),
-          optional(:has_more) => boolean,
-          optional(:url) => String.t()
+          id: Stripe.id(),
+          object: String.t(),
+          amount_subtotal: non_neg_integer,
+          amount_total: non_neg_integer,
+          currency: String.t(),
+          description: String.t(),
+          price: Stripe.Price.t(),
+          quantity: non_neg_integer
         }
 
   @type adjustable_quantity :: %{
@@ -250,7 +254,7 @@ defmodule Stripe.Session do
           optional(:currency) => String.t(),
           optional(:customer) => String.t(),
           optional(:customer_email) => String.t(),
-          optional(:line_items) => list(line_item_data()),
+          optional(:line_items) => list(line_item_create()),
           optional(:locale) => String.t(),
           optional(:metadata) => Stripe.Types.metadata(),
           optional(:after_expiration) => expiration(),
@@ -312,7 +316,7 @@ defmodule Stripe.Session do
           customer_creation: customer_creation() | nil,
           customer_details: customer_details() | nil,
           customer_email: String.t(),
-          line_items: list(line_item),
+          line_items: Stripe.List.t(line_item) | nil,
           expires_at: Stripe.timestamp() | nil,
           livemode: boolean(),
           locale: boolean(),


### PR DESCRIPTION
Noticed that the typespec of the `line_items` property was wrong, it was kinda doing a nested `Stripe.List` in a way, so this should fix it.

2 non-essential questions though:
1. Is there any reason why the line items are a simple map and not `Stripe.Checkout.Session.LineItems`? I've got the changes to the converter lined up if it should be the struct instead of a map, just wanted to keep the pull request simple.
2. Is there any reason for using `list(foo)` over `[foo]` in the typespecs? Took me a second to realize it was just the builtin `list()` type and not referring to the `Stripe.List`, and I personally feel like using the literal would be more explicit. Purely subjective though.