### PR TITLE
Make request_id a string instead of tuple

### DIFF
--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -453,7 +453,11 @@ defmodule Stripe.API do
   end
 
   defp handle_response({:ok, status, headers, body}) when status >= 300 and status <= 599 do
-    request_id = headers |> List.keyfind("Request-Id", 0)
+    request_id =
+      Enum.find_value(headers, fn
+        {"Request-Id", request_id} -> request_id
+        _header -> nil
+      end)
 
     error =
       case json_library().decode(body) do

--- a/test/stripe/api_test.exs
+++ b/test/stripe/api_test.exs
@@ -7,6 +7,10 @@ defmodule Stripe.APITest do
       Stripe.API.request(%{}, :get, "/", %{}, [])
   end
 
+  test "request_id is a string" do
+    {:error, %Stripe.Error{request_id: "req_123"}} = Stripe.API.request(%{}, :get, "/", %{}, [])
+  end
+
   test "oauth_request works" do
     verify_on_exit!()
 


### PR DESCRIPTION
The request_id in Stripe.Error was being set to a tuple that represented the "Request-Id" header. Now it will instead be a String like described in the typespec.