### PR TITLE
Make sure code is loaded before checking function_exported?, or it will be false

### DIFF
--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -116,6 +116,6 @@ defmodule Stripe.Converter do
   end
 
   defp known_struct?(struct) do
-    function_exported?(struct, :__struct__, 0)
+    Code.ensure_loaded?(struct) && function_exported?(struct, :__struct__, 0)
   end
 end


### PR DESCRIPTION
There is likely a better way to solve this, but wanted to put solution out for #793. This fixes my issue locally in test, although I didn't add test to library here. 

Happy to look into a test, although it will be a bit difficult as I believe that your local app's code is always fully loaded by Elixir.