### PR TITLE
Add :phone_number_collection to create_params

### DIFF
--- a/lib/stripe/checkout/session.ex
+++ b/lib/stripe/checkout/session.ex
@@ -262,6 +262,7 @@ defmodule Stripe.Session do
           optional(:expires_at) => Stripe.timestamp(),
           optional(:payment_intent_data) => payment_intent_data,
           optional(:payment_method_options) => payment_method_options(),
+          optional(:phone_number_collection) => phone_number_collection(),
           optional(:setup_intent_data) => setup_intent_data(),
           optional(:billing_address_collection) => billing_address_collection(),
           optional(:shipping_address_collection) => shipping_address_collection(),


### PR DESCRIPTION
This adds the `phone_number_collection` field to `create_params` in `Stripe.Session`.

This is intended to be applied against the 2.17.x line.