### PR TITLE
Allow returning responses as json.

### DIFF
--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -35,7 +35,7 @@ defmodule Stripe do
       duplicate requests to the stripe API. See [https://stripe.com/docs/api/idempotent_requests](https://stripe.com/docs/api/idempotent_requests)
     * `:response_as_json` - If set to `true`, the response will be returned as a
     JSON string instead of a struct. This is useful for persisting the original
-    response from stripe. You can use Stripe.Converter.convert_result/1 to structs
+    response from stripe. You can use Stripe.Converter.convert_result/1 to get structs
     from it.
 
   ### HTTP Connection Pool

--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -33,6 +33,10 @@ defmodule Stripe do
       from Stripe. See [https://stripe.com/docs/api/expanding_objects](https://stripe.com/docs/api/expanding_objects)
     * `:idempotency_key` - A string that is passed through as the "Idempotency-Key" header on all POST requests. This is used by Stripe's idempotency layer to manage
       duplicate requests to the stripe API. See [https://stripe.com/docs/api/idempotent_requests](https://stripe.com/docs/api/idempotent_requests)
+    * `:response_as_json` - If set to `true`, the response will be returned as a
+    JSON string instead of a struct. This is useful for persisting the original
+    response from stripe. You can use Stripe.Converter.convert_result/1 to structs
+    from it.
 
   ### HTTP Connection Pool
 

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -200,7 +200,11 @@ defmodule Stripe.Request do
     with {:ok, params} <- do_cast_to_id(params, request.cast_to_id),
          {:ok, endpoint} <- consolidate_endpoint(endpoint, params),
          {:ok, result} <- API.request(params, method, endpoint, headers, opts) do
-      {:ok, Converter.convert_result(result)}
+      if Keyword.get(opts, :response_as_json, false) do
+        {:ok, result}
+      else
+        {:ok, Converter.convert_result(result)}
+      end
     end
   end
 
@@ -210,11 +214,17 @@ defmodule Stripe.Request do
   @spec make_file_upload_request(t) :: {:ok, struct} | {:error, Stripe.Error.t()}
   def make_file_upload_request(
         %Request{params: params, endpoint: endpoint, method: method, opts: opts} = request
-      ) do
+  ) do
+
+
     with {:ok, params} <- do_cast_to_id(params, request.cast_to_id),
          {:ok, endpoint} <- consolidate_endpoint(endpoint, params),
          {:ok, result} <- API.request_file_upload(params, method, endpoint, %{}, opts) do
-      {:ok, Converter.convert_result(result)}
+      if Keyword.get(opts, :response_as_json, false) do
+        {:ok, result}
+      else
+        {:ok, Converter.convert_result(result)}
+      end
     end
   end
 


### PR DESCRIPTION
In order to persist stripe information to our database for faster retrieval, I found I had written a wrapper that was decoding stripe schemas manually into json, then storing it in json, then trying to fetch the json back out into structs. When the api version changes this gets complicated due to incompatibilities (like Stripe.Discount used to exist, now it doesn't, or just in general new fields that exist or are removed).

I really could just be storing the json from stripe and then converting these back into stripe structs for my code to make use of, getting stripity stripe out of the chain.