### PR TITLE
Fix TestClock Module Name

### DIFF
--- a/lib/stripe/util.ex
+++ b/lib/stripe/util.ex
@@ -80,7 +80,7 @@ defmodule Stripe.Util do
   def object_name_to_module("terminal.connection_token"), do: Stripe.Terminal.ConnectionToken
   def object_name_to_module("terminal.location"), do: Stripe.Terminal.Location
   def object_name_to_module("terminal.reader"), do: Stripe.Terminal.Reader
-  def object_name_to_module("test_helpers.test_clock"), do: Stripe.TestClock
+  def object_name_to_module("test_helpers.test_clock"), do: Stripe.TestHelpers.TestClock
 
   def object_name_to_module("usage_record_summary"),
     do: Stripe.UsageRecordSummary


### PR DESCRIPTION
Fixes https://github.com/beam-community/stripity-stripe/issues/810.

It seems one occurrence of the old struct name Stripe.TestClock was not renamed to Stripe.TestHelpers.TestClock.

This is the second attempt to fix this. My first PR was targeted at the old `master` branch. This one targets the new `main` branch.