### PR TITLE
Use conn token from read_body result

### DIFF
--- a/lib/stripe/webhook_plug.ex
+++ b/lib/stripe/webhook_plug.ex
@@ -132,7 +132,7 @@ if Code.ensure_loaded?(Plug) do
       secret = parse_secret!(secret)
 
       with [signature] <- get_req_header(conn, "stripe-signature"),
-           {:ok, payload, _} = Conn.read_body(conn),
+           {:ok, payload, conn} = Conn.read_body(conn),
            {:ok, %Stripe.Event{} = event} <- construct_event(payload, signature, secret, opts),
            :ok <- handle_event!(handler, event) do
         send_resp(conn, 200, "Webhook received.") |> halt()


### PR DESCRIPTION
The `conn` token returned from `Conn.read_body/1` function should not be ignored as it may contain vital state regarding the connection which has been altered by this function.

For example when using [bandit](https://github.com/mtrudel/bandit) ignoring conn will cause the keepalive mechanism to malfunction! (See mtrudel/bandit#260)

From `Plug.Conn.read_body` docs:
> Like all functions in this module, the conn returned by read_body must be passed to the next stage of your pipeline and should not be ignored.
