### PR TITLE
Fix object module lookup for Test Clock

### DIFF
--- a/lib/stripe/util.ex
+++ b/lib/stripe/util.ex
@@ -51,7 +51,7 @@ defmodule Stripe.Util do
   def atomize_key(k), do: k
 
   @spec object_name_to_module(String.t()) :: module
-  def object_name_to_module("test_helpers.test_clock"), do: Stripe.TestClock
+  def object_name_to_module("test_helpers.test_clock"), do: Stripe.TestHelpers.TestClock
 
   def object_name_to_module(object_name) do
     module_parts =

--- a/test/stripe/util_test.exs
+++ b/test/stripe/util_test.exs
@@ -50,6 +50,7 @@ defmodule Stripe.UtilTest do
       assert object_name_to_module("terminal.reader") == Stripe.Terminal.Reader
       assert object_name_to_module("terminal.location") == Stripe.Terminal.Location
       assert object_name_to_module("terminal.connection_token") == Stripe.Terminal.ConnectionToken
+      assert object_name_to_module("test_helpers.test_clock") == Stripe.TestHelpers.TestClock
       assert object_name_to_module("usage_record") == Stripe.UsageRecord
       assert object_name_to_module("usage_record_summary") == Stripe.UsageRecordSummary
     end


### PR DESCRIPTION
This fixes the bug described in https://github.com/beam-community/stripity-stripe/issues/825. It's a simple fix- the module name just needed fixed. I also included the lookup in the util test since it was missing and shouldn't happen again now that there is a test for it. 

I ran the test suite locally and everything passed 