### PR TITLE
small updates to Telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,9 @@ jobs:
       with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
-    - name: Mix Dependencies
-      run: mix deps.get
-    - name: Test
-      run: mix test
+    - run: mix deps.get
+    - run: mix compile
+    - run: mix test --trace
 
   lint:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       STRIPE_MOCK_VERSION: 0.144.0
       STRIPE_SECRET_KEY: non_empty_string
       SKIP_STRIPE_MOCK_RUN: true
+      SHELL: bash
     runs-on: ubuntu-20.04
     name: Test (OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}})
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,4 @@ jobs:
       - run: mix compile --warnings-as-errors
       - run: mix dialyzer --halt-exit-status
       - run: mix deps.unlock --check-unused
+      - run: mix format --check-formatted

--- a/test/stripe/api_test.exs
+++ b/test/stripe/api_test.exs
@@ -115,14 +115,18 @@ defmodule Stripe.APITest do
         [:stripe, :request, :stop],
         %{monotonic_time: _, duration: _},
         %{
-          telemetry_span_context: _,
-          endpoint: "/v1/customers/search",
-          attempt: 0,
-          method: :get,
-          status: 200,
-          stripe_api_version: _
+          http_method: :get,
+          http_retry_count: 0,
+          http_status_code: 200,
+          http_url: http_url,
+          stripe_api_version: _,
+          stripe_api_endpoint: "/v1/customers/search",
+          telemetry_span_context: _
         }
       })
+
+      assert String.ends_with?(http_url, "/v1/customers/search")
+      assert not String.contains?(http_url, "test@example.com")
     end
   end
 

--- a/test/stripe/util_test.exs
+++ b/test/stripe/util_test.exs
@@ -37,8 +37,13 @@ defmodule Stripe.UtilTest do
 
       assert object_name_to_module("billing_portal.session") == Stripe.BillingPortal.Session
       assert object_name_to_module("checkout.session") == Stripe.Checkout.Session
-      assert object_name_to_module("identity.verification_report") == Stripe.Identity.VerificationReport
-      assert object_name_to_module("identity.verification_session") == Stripe.Identity.VerificationSession
+
+      assert object_name_to_module("identity.verification_report") ==
+               Stripe.Identity.VerificationReport
+
+      assert object_name_to_module("identity.verification_session") ==
+               Stripe.Identity.VerificationSession
+
       assert object_name_to_module("issuing.authorization") == Stripe.Issuing.Authorization
       assert object_name_to_module("issuing.card") == Stripe.Issuing.Card
       assert object_name_to_module("issuing.cardholder") == Stripe.Issuing.Cardholder

--- a/test/support/stripe_mock_test.exs
+++ b/test/support/stripe_mock_test.exs
@@ -10,7 +10,7 @@ defmodule Stripe.StripeMockTest do
 
   defp assert_port_open(port) do
     delay()
-    assert {:ok, socket} = :gen_tcp.connect('localhost', port, [])
+    assert {:ok, socket} = :gen_tcp.connect(~c"localhost", port, [])
     :gen_tcp.close(socket)
   end
 


### PR DESCRIPTION
Hi there, I added some telemetry around webhook handler and changed metadata included in all API requests. It's all just a few small changes to make monitoring for stripity-stripe users awesome out of the box 🙃 

Webhooks are often important part of integration with Stripe so having telemetry in there is good idea imo.

API requests metadata contains some low cardinality fields that can be useful when visualising these metrics in other tools. For example using `stripe.request.stop` event we can infer metrics for RED method and also have visibility into individual Stripe API endpoints.

There are no breaking changes in here, only telemetry metadata is different (`url` field is gone). There is assumption that `event` object always contains `type` property, which is always a case to my knowledge and Stripe docs.

Here is example how it looks in PhoenixLiveDashboard:

![image](https://github.com/beam-community/stripity-stripe/assets/853568/1d286b8e-2d04-4435-83bc-426158802ff2)

In order to enable this visualisation I only needed to add few lines to `telemetry.ex`:

```elixir
      # Stripe
      summary("stripe.request.stop.duration",
        tags: [:endpoint, :status],
        unit: {:native, :millisecond}
      ),
      summary("stripe.webhook.stop.duration",
        tags: [:event],
        unit: {:native, :millisecond}
      ),
```

Other systems such as prom_ex, telemetry_ui, otel, etc can be easily integrated too.

Hope you like it, happy to take in any and all feedback.