### PR TITLE
Make hackney an optional dependency

### DIFF
--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -34,17 +34,23 @@ defmodule Stripe.API do
     Config.resolve(:json_library, Jason)
   end
 
-  def supervisor_children do
-    if use_pool?() do
-      [:hackney_pool.child_spec(@pool_name, get_pool_options())]
-    else
+  if Code.loaded?(:hackney_pool) do
+    @spec get_pool_options() :: Keyword.t()
+    defp get_pool_options() do
+      Config.resolve(:pool_options)
+    end
+
+    def supervisor_children do
+      if use_pool?() do
+        [:hackney_pool.child_spec(@pool_name, get_pool_options())]
+      else
+        []
+      end
+    end
+  else
+    def supervisor_children do
       []
     end
-  end
-
-  @spec get_pool_options() :: Keyword.t()
-  defp get_pool_options() do
-    Config.resolve(:pool_options)
   end
 
   @spec get_base_url() :: String.t()

--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -490,11 +490,9 @@ defmodule Stripe.API do
   end
 
   defp decompress_body(body, headers) do
-    headers_dict = :hackney_headers.new(headers)
-
-    case :hackney_headers.get_value("Content-Encoding", headers_dict) do
-      "gzip" -> :zlib.gunzip(body)
-      "deflate" -> :zlib.unzip(body)
+    case List.keyfind(headers, "content-encoding", 0) do
+      {"content-encoding", "gzip"} -> :zlib.gunzip(body)
+      {"content-encoding", "deflate"} -> :zlib.unzip(body)
       _ -> body
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -30,11 +30,14 @@ defmodule Stripe.Mixfile do
   # Configuration for the OTP application
   def application do
     [
-      extra_applications: [:plug],
+      extra_applications: extra_applications(Mix.env()),
       env: env(),
       mod: {Stripe, []}
     ]
   end
+
+  defp extra_applications(:test), do: [:plug, :hackney]
+  defp extra_applications(_), do: []
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support"]
@@ -54,7 +57,7 @@ defmodule Stripe.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 1.18"},
+      {:hackney, "~> 1.18", optional: true},
       {:jason, "~> 1.1"},
       {:telemetry, "~> 1.1"},
       {:uri_query, "~> 0.2.0"},

--- a/test/stripe/util_test.exs
+++ b/test/stripe/util_test.exs
@@ -37,8 +37,13 @@ defmodule Stripe.UtilTest do
 
       assert object_name_to_module("billing_portal.session") == Stripe.BillingPortal.Session
       assert object_name_to_module("checkout.session") == Stripe.Checkout.Session
-      assert object_name_to_module("identity.verification_report") == Stripe.Identity.VerificationReport
-      assert object_name_to_module("identity.verification_session") == Stripe.Identity.VerificationSession
+
+      assert object_name_to_module("identity.verification_report") ==
+               Stripe.Identity.VerificationReport
+
+      assert object_name_to_module("identity.verification_session") ==
+               Stripe.Identity.VerificationSession
+
       assert object_name_to_module("issuing.authorization") == Stripe.Issuing.Authorization
       assert object_name_to_module("issuing.card") == Stripe.Issuing.Card
       assert object_name_to_module("issuing.cardholder") == Stripe.Issuing.Cardholder

--- a/test/support/stripe_mock_test.exs
+++ b/test/support/stripe_mock_test.exs
@@ -10,7 +10,7 @@ defmodule Stripe.StripeMockTest do
 
   defp assert_port_open(port) do
     delay()
-    assert {:ok, socket} = :gen_tcp.connect('localhost', port, [])
+    assert {:ok, socket} = :gen_tcp.connect(~c"localhost", port, [])
     :gen_tcp.close(socket)
   end
 


### PR DESCRIPTION
Requiring `:hackney` brings in a ton of additional dependencies that can be avoided.

Unsure about how to add useful tests, some that set `:http_module` [already exist](https://github.com/beam-community/stripity-stripe/blob/73faf6d3e4b021471db7f2768cf2fbdd69055557/test/stripe/api_test.exs#L107-L168).