### PR TITLE
Fix Stripe.File.create

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule Stripe.Mixfile do
   defp env do
     [
       api_base_url: "https://api.stripe.com",
-      api_upload_url: "https://files.stripe.com/v1/",
+      api_upload_url: "https://files.stripe.com",
       pool_options: [
         timeout: 5_000,
         max_connections: 10

--- a/test/fixtures/upload.txt
+++ b/test/fixtures/upload.txt
@@ -1,0 +1,1 @@
+# file to upload

--- a/test/stripe/core_resources/file_upload_test.exs
+++ b/test/stripe/core_resources/file_upload_test.exs
@@ -1,12 +1,11 @@
 defmodule Stripe.FileTest do
   use Stripe.StripeCase, async: true
 
-  @tag :skip
   describe "create/2" do
     test "creates a file" do
       assert {:ok, %Stripe.File{}} =
                Stripe.File.create(%{
-                 file: "@/path/to/a/file.jpg",
+                 file: Path.join(__DIR__, "../../fixtures/upload.txt"),
                  purpose: "dispute_evidence"
                })
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,7 +11,7 @@ unless System.get_env("SKIP_STRIPE_MOCK_RUN") do
 end
 
 api_base_url = System.get_env("STRIPE_API_BASE_URL") || "http://localhost:12111"
-api_upload_url = System.get_env("STRIPE_API_UPLOAD_URL") || "http://localhost:12112/v1/"
+api_upload_url = System.get_env("STRIPE_API_UPLOAD_URL") || "http://localhost:12111"
 
 Application.put_env(:stripity_stripe, :api_base_url, api_base_url)
 Application.put_env(:stripity_stripe, :api_upload_url, api_upload_url)


### PR DESCRIPTION
### Problem: `Stripe.File.create` was failing

- It seems that this library was building the wrong url, ending in `/v1//v1/files`. This was fixed by changing the config variable `api_upload_url`.
- The test for file upload was skipped, presumably because `stripe-mock` used not to support it. It does now, so I've enabled the test and fixed it.
- Lastly, I changed an existing test which is failing for me, but I'm not sure if this will break other people's tests. It is in `test/stripe/subscriptions/credit_note_test.exs` and it only involves the order of query parameters. Hopefully this fix is stable.