### PR TITLE
chore: fix Elixir 1.17 warnings

### DIFF
--- a/lib/stripe/converter.ex
+++ b/lib/stripe/converter.ex
@@ -38,7 +38,7 @@ defmodule Stripe.Converter do
   @spec convert_stripe_object(%{String.t() => any}) :: struct
   defp convert_stripe_object(%{"object" => object_name} = value) do
     module = Stripe.Util.object_name_to_module(object_name)
-    struct_keys = Map.keys(module.__struct__) |> List.delete(:__struct__)
+    struct_keys = Map.keys(module.__struct__()) |> List.delete(:__struct__)
     check_for_extra_keys(struct_keys, value)
 
     processed_map =

--- a/test/support/stripe_mock_test.exs
+++ b/test/support/stripe_mock_test.exs
@@ -10,7 +10,7 @@ defmodule Stripe.StripeMockTest do
 
   defp assert_port_open(port) do
     delay()
-    assert {:ok, socket} = :gen_tcp.connect('localhost', port, [])
+    assert {:ok, socket} = :gen_tcp.connect(~c'localhost', port, [])
     :gen_tcp.close(socket)
   end
 


### PR DESCRIPTION
Resolves the following warnings:

```
using map.field notation (without parentheses) to invoke function Stripe.CountrySpec.__struct__() is deprecated, you must add parentheses instead: remote.function()
```

```
single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
```