### PR TITLE
chore: Improving Github Actions code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - synchronize
   push:
     branches:
-      - master
+      - main
   merge_group:
 
 jobs:
@@ -19,60 +19,60 @@ jobs:
       STRIPE_SECRET_KEY: non_empty_string
       SKIP_STRIPE_MOCK_RUN: true
       SHELL: /bin/bash # erlexec needs this
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Test (OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}})
     strategy:
-       matrix:
-         elixir: ['1.14', '1.15', '1.16']
-         otp: [24, 25, 26]
+      matrix:
+        elixir: ["1.14", "1.15", "1.16"]
+        otp: [24, 25, 26]
     services:
-       stripe-mock:
-         image: stripe/stripe-mock:v0.144.0
-         ports:
-           - 12111:12111
-           - 12112:12112
+      stripe-mock:
+        image: stripe/stripe-mock:v0.144.0
+        ports:
+          - 12111:12111
+          - 12112:12112
     steps:
-    - name: Clone code
-      uses: actions/checkout@v2
-    - name: Setup Elixir and Erlang
-      uses: erlef/setup-beam@v1
-      with:
+      - name: Clone code
+        uses: actions/checkout@v4
+      - name: Setup Elixir and Erlang
+        uses: erlef/setup-beam@v1
+        with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
-    - name: Mix Dependencies
-      run: mix deps.get
-    - name: Test
-      run: mix test
+      - name: Mix Dependencies
+        run: mix deps.get
+      - name: Test
+        run: mix test
 
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Linting
     strategy:
-       matrix:
-         elixir: ['1.16']
-         otp: ["26"]
+      matrix:
+        elixir: ["1.17"]
+        otp: ["27"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: mix
         with:
           path: ~/.mix
           key: cache-${{ runner.os }}-${{ env.cache-name }}-${{ matrix.otp }}-${{ matrix.elixir }}
           restore-keys: |
-             cache-${{ runner.os }}-${{ env.cache-name }}-
-      - uses: actions/cache@v1
+            cache-${{ runner.os }}-${{ env.cache-name }}-
+      - uses: actions/cache@v4
         env:
           cache-name: build
         with:
           path: _build
           key: cache-${{ runner.os }}-${{ env.cache-name }}-${{ matrix.otp }}-${{ matrix.elixir }}
           restore-keys: |
-             cache-${{ runner.os }}-${{ env.cache-name }}-
+            cache-${{ runner.os }}-${{ env.cache-name }}-
       - run: mix deps.get
       - run: mix compile --warnings-as-errors
       - run: mix dialyzer --halt-exit-status

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -7,61 +7,57 @@ on:
       - main
   schedule:
     ## Scheduled nightly at 00:23
-    - cron: '23 0 * * *'
+    - cron: "23 0 * * *"
 
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Check if changed
     strategy:
       fail-fast: false
 
-    outputs:
-      current_tag: ${{ steps.current-tag.outputs.CURRENT_TAG }}
-      latest_tag: ${{ steps.latest-tag.outputs.LATEST_TAG }}
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Get tag used for generated files
         id: current-tag
         run: |
           # check if the file exist before
           [[ -f .latest-tag-stripe-openapi-sdk ]] && CURRENT_TAG=$(<.latest-tag-stripe-openapi-sdk) || CURRENT_TAG=''
-          echo "::set-output name=CURRENT_TAG::${CURRENT_TAG}"
+          echo "current_tag::${CURRENT_TAG}" >> $GITHUB_OUTPUT
       - name: Get latest Stripe SDK tag
         id: latest-tag
         run: |
           wget https://api.github.com/repos/stripe/openapi/releases/latest
           tag_name=$(cat latest | jq -r '.tag_name')
-          echo "::set-output name=LATEST_TAG::${tag_name}"
+          echo "latest_tag::${tag_name}" >> $GITHUB_OUTPUT
   generate:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Update services
     needs: check
-    if: ${{ needs.check.outputs.current_tag != needs.check.outputs.latest_tag }}
+    if: ${{ steps.current-tag.outputs.current_tag != steps.latest-tags.outputs.latest_tag }}
 
     env:
-      LATEST_STRIPE_SDK_TAG: ${{ needs.check.outputs.latest_tag }}
+      LATEST_STRIPE_SDK_TAG: ${{ steps.latest-tag.outputs.latest_tag }}
       SKIP_STRIPE_MOCK_RUN: true
 
     strategy:
       fail-fast: false
     services:
-       stripe-mock:
-         image: stripe/stripe-mock:v0.144.0
-         ports:
-           - 12111:12111
-           - 12112:12112
+      stripe-mock:
+        image: stripe/stripe-mock:v0.144.0
+        ports:
+          - 12111:12111
+          - 12112:12112
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "26"
-          elixir-version: "1.16"
+          otp-version: "27"
+          elixir-version: "1.17"
 
       - name: Checkout stripe/openapi (official OpenApi definitions)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: stripe/openapi
           path: tmp/openapi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,11 +10,11 @@ jobs:
     env:
       HEX_API_KEY: ${{ secrets.HEXPM_SECRET }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "26"
-          elixir-version: "1.16"
+          otp-version: "27"
+          elixir-version: "1.17"
       - run: mix deps.get
       - run: mix compile --docs
       - run: mix hex.publish --yes

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,9 +1,9 @@
-name: 'Close stale issues and PRs'
+name: "Close stale issues and PRs"
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: "30 1 * * *"
 
 permissions:
   contents: write
@@ -14,15 +14,15 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v9
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 15
           days-before-pr-stale: 60
           days-before-pr-close: 60
 
-          stale-issue-label: 'stale:discard'
-          exempt-issue-labels: 'stale:keep'
+          stale-issue-label: "stale:discard"
+          exempt-issue-labels: "stale:keep"
           stale-issue-message: >
             This issue has been automatically marked as "stale:discard". **If this issue still relevant, please leave
             any comment** (for example, "bump"), and we'll keep it open. We are sorry that we haven't been able to
@@ -32,8 +32,8 @@ jobs:
             Closing this issue after a prolonged period of inactivity. If this issue is still relevant, feel free to
             re-open the issue. Thank you!
 
-          stale-pr-label: 'stale:discard'
-          exempt-pr-labels: 'stale:keep'
+          stale-pr-label: "stale:discard"
+          exempt-pr-labels: "stale:keep"
           stale-pr-message: >
             This pull request has been automatically marked as "stale:discard". **If this pull request is still
             relevant, please leave any comment** (for example, "bump"), and we'll keep it open. We are sorry that we


### PR DESCRIPTION
* Properly formatting
* master -> main
* Update ubuntu from 20.04 to latest
* Update actions to newest version
* Running lints and generation with elixir 1.17 and otp 27
* Replace deprecated `::set-output` with env vars

I didn't add elixir `1.17` to the test matrix because I'd have to remove `1.14` since `1.17` isn't compatible with OTP `24`which is required for `1.14`. If we decide to drop `1.14` support we could do it.