### PR TITLE
feat: merge start metadata in stop metadata, include attempts

### DIFF
--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -376,11 +376,13 @@ defmodule Stripe.API do
   end
 
   defp do_perform_request_and_retry(method, url, headers, body, opts, {:attempts, attempts}) do
+    start_metadata = %{url: url, method: method, attempts: attempts}
+
     response =
-      :telemetry.span(~w[stripe request]a, %{url: url, method: method}, fn ->
+      :telemetry.span(~w[stripe request]a, start_metadata, fn ->
         case http_module().request(method, url, Map.to_list(headers), body, opts) do
           {:ok, status, _, _} = resp ->
-            {resp, %{status: status}}
+            {resp, Map.merge(start_metadata, %{status: status})}
 
           error ->
             {error, %{}}


### PR DESCRIPTION
This PR includes the `start_metadata` in the `stop_metadata`, as recommended in the docs for [`:telemetry.span/3`](https://hexdocs.pm/telemetry/telemetry.html#span/3):

> In general, it is highly recommended that StopMetadata should include the values from StartMetadata so that handlers, such as those used for metrics, can rely entirely on the stop event.

We also include the `attempts` key in the metadata.