### PR TITLE
docs: fix stripe webhookplug secret function format

### DIFF
--- a/lib/stripe/webhook_plug.ex
+++ b/lib/stripe/webhook_plug.ex
@@ -102,7 +102,7 @@ if Code.ensure_loaded?(Plug) do
     plug Stripe.WebhookPlug,
       at: "/webhook/stripe",
       handler: MyAppWeb.StripeHandler,
-      secret: fn -> Application.get_env(:myapp, :stripe_webhook_secret) end
+      secret: &MyAppWeb.Secrets.stripe_webhook_secret/0 # a remote function in the format &Mod.fun/arity
     ```
     """
 


### PR DESCRIPTION
Anonymous functions aren't supported and throw
```
** (ArgumentError) cannot escape #Function<>. The supported values are: lists, tuples, maps, atoms, numbers, bitstrings, PIDs and remote functions in the format &Mod.fun/arity
```

Only an MFA is supported