### PR TITLE
Update to current spec and fix Account's spec

### DIFF
--- a/lib/generated/account.ex
+++ b/lib/generated/account.ex
@@ -66,7 +66,7 @@ defmodule Stripe.Account do
   )
 
   (
-    @typedoc "The individual's primary address."
+    @typedoc "The company's primary address."
     @type address :: %{
             optional(:city) => binary,
             optional(:country) => binary,
@@ -78,7 +78,7 @@ defmodule Stripe.Account do
   )
 
   (
-    @typedoc "The Kana variation of the the individual's primary address (Japan only)."
+    @typedoc "The Kana variation of the company's primary address (Japan only)."
     @type address_kana :: %{
             optional(:city) => binary,
             optional(:country) => binary,
@@ -91,7 +91,7 @@ defmodule Stripe.Account do
   )
 
   (
-    @typedoc "The Kanji variation of the company's primary address (Japan only)."
+    @typedoc "The Kanji variation of the the individual's primary address (Japan only)."
     @type address_kanji :: %{
             optional(:city) => binary,
             optional(:country) => binary,
@@ -222,13 +222,8 @@ defmodule Stripe.Account do
   )
 
   (
-    @typedoc "Settings specific to card charging on the account."
-    @type card_payments :: %{
-            optional(:decline_on) => decline_on,
-            optional(:statement_descriptor_prefix) => binary,
-            optional(:statement_descriptor_prefix_kana) => binary | binary,
-            optional(:statement_descriptor_prefix_kanji) => binary | binary
-          }
+    @typedoc "The card_payments capability."
+    @type card_payments :: %{optional(:requested) => boolean}
   )
 
   (
@@ -583,12 +578,11 @@ defmodule Stripe.Account do
   )
 
   (
-    @typedoc "Details on the account's acceptance of the [Stripe Services Agreement](https://stripe.com/docs/connect/updating-accounts#tos-acceptance)."
+    @typedoc "Details on the account's acceptance of the [Stripe Issuing Terms and Disclosures](https://stripe.com/docs/issuing/connect/tos_acceptance)."
     @type tos_acceptance :: %{
             optional(:date) => integer,
             optional(:ip) => binary,
-            optional(:service_agreement) => binary,
-            optional(:user_agent) => binary
+            optional(:user_agent) => binary | binary
           }
   )
 
@@ -608,8 +602,11 @@ defmodule Stripe.Account do
   )
 
   (
-    @typedoc "Information on the verification state of the company."
-    @type verification :: %{optional(:document) => document}
+    @typedoc "The individual's verification document information."
+    @type verification :: %{
+            optional(:additional_document) => additional_document,
+            optional(:document) => document
+          }
   )
 
   (
@@ -622,10 +619,51 @@ defmodule Stripe.Account do
 
     @doc "<p>Retrieves the details of an account.</p>\n\n#### Details\n\n * Method: `get`\n * Path: `/v1/account`\n"
     (
-      @spec retrieve(params :: %{optional(:expand) => list(binary)}, opts :: Keyword.t()) ::
+      @spec show(params :: %{optional(:expand) => list(binary)}, opts :: Keyword.t()) ::
               {:ok, Stripe.Account.t()} | {:error, Stripe.ApiErrors.t()} | {:error, term()}
-      def retrieve(params \\ %{}, opts \\ []) do
+      def show(params \\ %{}, opts \\ []) do
         path = Stripe.OpenApi.Path.replace_path_params("/v1/account", [], [])
+
+        Stripe.Request.new_request(opts)
+        |> Stripe.Request.put_endpoint(path)
+        |> Stripe.Request.put_params(params)
+        |> Stripe.Request.put_method(:get)
+        |> Stripe.Request.make_request()
+      end
+    )
+  )
+
+  (
+    nil
+
+    @doc "<p>Retrieves the details of an account.</p>\n\n#### Details\n\n * Method: `get`\n * Path: `/v1/accounts/{account}`\n"
+    (
+      @spec retrieve(
+              account :: binary(),
+              params :: %{optional(:expand) => list(binary)},
+              opts :: Keyword.t()
+            ) :: {:ok, Stripe.Account.t()} | {:error, Stripe.ApiErrors.t()} | {:error, term()}
+      def retrieve(account, params \\ %{}, opts \\ []) do
+        path =
+          Stripe.OpenApi.Path.replace_path_params(
+            "/v1/accounts/{account}",
+            [
+              %OpenApiGen.Blueprint.Parameter{
+                in: "path",
+                name: "account",
+                required: true,
+                schema: %OpenApiGen.Blueprint.Parameter.Schema{
+                  name: "account",
+                  title: nil,
+                  type: "string",
+                  items: [],
+                  properties: [],
+                  any_of: []
+                }
+              }
+            ],
+            [account]
+          )
 
         Stripe.Request.new_request(opts)
         |> Stripe.Request.put_endpoint(path)

--- a/lib/generated/bank_account.ex
+++ b/lib/generated/bank_account.ex
@@ -62,6 +62,18 @@ defmodule Stripe.BankAccount do
   )
 
   (
+    @typedoc "One or more documents that support the [Bank account ownership verification](https://support.stripe.com/questions/bank-account-ownership-verification) requirement. Must be a document associated with the bank account that displays the last 4 digits of the account number, either a statement or a voided check."
+    @type bank_account_ownership_verification :: %{optional(:files) => list(binary)}
+  )
+
+  (
+    @typedoc "Documents that may be submitted to satisfy various informational requests."
+    @type documents :: %{
+            optional(:bank_account_ownership_verification) => bank_account_ownership_verification
+          }
+  )
+
+  (
     @typedoc nil
     @type owner :: %{
             optional(:address) => address,
@@ -76,7 +88,7 @@ defmodule Stripe.BankAccount do
 
     @doc "<p>Update a specified source for a given customer.</p>\n\n#### Details\n\n * Method: `post`\n * Path: `/v1/customers/{customer}/sources/{id}`\n"
     (
-      @spec update(
+      @spec update_source(
               customer :: binary(),
               id :: binary(),
               params :: %{
@@ -100,7 +112,7 @@ defmodule Stripe.BankAccount do
               {:ok, Stripe.Card.t() | Stripe.BankAccount.t() | Stripe.Source.t()}
               | {:error, Stripe.ApiErrors.t()}
               | {:error, term()}
-      def update(customer, id, params \\ %{}, opts \\ []) do
+      def update_source(customer, id, params \\ %{}, opts \\ []) do
         path =
           Stripe.OpenApi.Path.replace_path_params(
             "/v1/customers/{customer}/sources/{id}",
@@ -149,7 +161,7 @@ defmodule Stripe.BankAccount do
 
     @doc "<p>Delete a specified source for a given customer.</p>\n\n#### Details\n\n * Method: `delete`\n * Path: `/v1/customers/{customer}/sources/{id}`\n"
     (
-      @spec delete(
+      @spec delete_source(
               customer :: binary(),
               id :: binary(),
               params :: %{optional(:expand) => list(binary)},
@@ -158,7 +170,7 @@ defmodule Stripe.BankAccount do
               {:ok, Stripe.PaymentSource.t() | Stripe.DeletedPaymentSource.t()}
               | {:error, Stripe.ApiErrors.t()}
               | {:error, term()}
-      def delete(customer, id, params \\ %{}, opts \\ []) do
+      def delete_source(customer, id, params \\ %{}, opts \\ []) do
         path =
           Stripe.OpenApi.Path.replace_path_params(
             "/v1/customers/{customer}/sources/{id}",
@@ -252,6 +264,133 @@ defmodule Stripe.BankAccount do
         |> Stripe.Request.put_endpoint(path)
         |> Stripe.Request.put_params(params)
         |> Stripe.Request.put_method(:post)
+        |> Stripe.Request.make_request()
+      end
+    )
+  )
+
+  (
+    nil
+
+    @doc "<p>Updates the metadata, account holder name, account holder type of a bank account belonging to a <a href=\"/docs/connect/custom-accounts\">Custom account</a>, and optionally sets it as the default for its currency. Other bank account details are not editable by design.</p>\n\n<p>You can re-enable a disabled bank account by performing an update call without providing any arguments or changes.</p>\n\n#### Details\n\n * Method: `post`\n * Path: `/v1/accounts/{account}/external_accounts/{id}`\n"
+    (
+      @spec update_external_account(
+              account :: binary(),
+              id :: binary(),
+              params :: %{
+                optional(:account_holder_name) => binary,
+                optional(:account_holder_type) => :company | :individual,
+                optional(:account_type) => :checking | :futsu | :savings | :toza,
+                optional(:address_city) => binary,
+                optional(:address_country) => binary,
+                optional(:address_line1) => binary,
+                optional(:address_line2) => binary,
+                optional(:address_state) => binary,
+                optional(:address_zip) => binary,
+                optional(:default_for_currency) => boolean,
+                optional(:documents) => documents,
+                optional(:exp_month) => binary,
+                optional(:exp_year) => binary,
+                optional(:expand) => list(binary),
+                optional(:metadata) => %{optional(binary) => binary} | binary,
+                optional(:name) => binary
+              },
+              opts :: Keyword.t()
+            ) ::
+              {:ok, Stripe.ExternalAccount.t()}
+              | {:error, Stripe.ApiErrors.t()}
+              | {:error, term()}
+      def update_external_account(account, id, params \\ %{}, opts \\ []) do
+        path =
+          Stripe.OpenApi.Path.replace_path_params(
+            "/v1/accounts/{account}/external_accounts/{id}",
+            [
+              %OpenApiGen.Blueprint.Parameter{
+                in: "path",
+                name: "account",
+                required: true,
+                schema: %OpenApiGen.Blueprint.Parameter.Schema{
+                  name: "account",
+                  title: nil,
+                  type: "string",
+                  items: [],
+                  properties: [],
+                  any_of: []
+                }
+              },
+              %OpenApiGen.Blueprint.Parameter{
+                in: "path",
+                name: "id",
+                required: true,
+                schema: %OpenApiGen.Blueprint.Parameter.Schema{
+                  name: "id",
+                  title: nil,
+                  type: "string",
+                  items: [],
+                  properties: [],
+                  any_of: []
+                }
+              }
+            ],
+            [account, id]
+          )
+
+        Stripe.Request.new_request(opts)
+        |> Stripe.Request.put_endpoint(path)
+        |> Stripe.Request.put_params(params)
+        |> Stripe.Request.put_method(:post)
+        |> Stripe.Request.make_request()
+      end
+    )
+  )
+
+  (
+    nil
+
+    @doc "<p>Delete a specified external account for a given account.</p>\n\n#### Details\n\n * Method: `delete`\n * Path: `/v1/accounts/{account}/external_accounts/{id}`\n"
+    (
+      @spec delete_external_account(account :: binary(), id :: binary(), opts :: Keyword.t()) ::
+              {:ok, Stripe.DeletedExternalAccount.t()}
+              | {:error, Stripe.ApiErrors.t()}
+              | {:error, term()}
+      def delete_external_account(account, id, opts \\ []) do
+        path =
+          Stripe.OpenApi.Path.replace_path_params(
+            "/v1/accounts/{account}/external_accounts/{id}",
+            [
+              %OpenApiGen.Blueprint.Parameter{
+                in: "path",
+                name: "account",
+                required: true,
+                schema: %OpenApiGen.Blueprint.Parameter.Schema{
+                  name: "account",
+                  title: nil,
+                  type: "string",
+                  items: [],
+                  properties: [],
+                  any_of: []
+                }
+              },
+              %OpenApiGen.Blueprint.Parameter{
+                in: "path",
+                name: "id",
+                required: true,
+                schema: %OpenApiGen.Blueprint.Parameter.Schema{
+                  name: "id",
+                  title: nil,
+                  type: "string",
+                  items: [],
+                  properties: [],
+                  any_of: []
+                }
+              }
+            ],
+            [account, id]
+          )
+
+        Stripe.Request.new_request(opts)
+        |> Stripe.Request.put_endpoint(path)
+        |> Stripe.Request.put_method(:delete)
         |> Stripe.Request.make_request()
       end
     )

--- a/lib/generated/card.ex
+++ b/lib/generated/card.ex
@@ -86,6 +86,18 @@ defmodule Stripe.Card do
   )
 
   (
+    @typedoc "One or more documents that support the [Bank account ownership verification](https://support.stripe.com/questions/bank-account-ownership-verification) requirement. Must be a document associated with the bank account that displays the last 4 digits of the account number, either a statement or a voided check."
+    @type bank_account_ownership_verification :: %{optional(:files) => list(binary)}
+  )
+
+  (
+    @typedoc "Documents that may be submitted to satisfy various informational requests."
+    @type documents :: %{
+            optional(:bank_account_ownership_verification) => bank_account_ownership_verification
+          }
+  )
+
+  (
     @typedoc nil
     @type owner :: %{
             optional(:address) => address,
@@ -100,7 +112,7 @@ defmodule Stripe.Card do
 
     @doc "<p>Update a specified source for a given customer.</p>\n\n#### Details\n\n * Method: `post`\n * Path: `/v1/customers/{customer}/sources/{id}`\n"
     (
-      @spec update(
+      @spec update_source(
               customer :: binary(),
               id :: binary(),
               params :: %{
@@ -124,7 +136,7 @@ defmodule Stripe.Card do
               {:ok, Stripe.Card.t() | Stripe.BankAccount.t() | Stripe.Source.t()}
               | {:error, Stripe.ApiErrors.t()}
               | {:error, term()}
-      def update(customer, id, params \\ %{}, opts \\ []) do
+      def update_source(customer, id, params \\ %{}, opts \\ []) do
         path =
           Stripe.OpenApi.Path.replace_path_params(
             "/v1/customers/{customer}/sources/{id}",
@@ -173,7 +185,7 @@ defmodule Stripe.Card do
 
     @doc "<p>Delete a specified source for a given customer.</p>\n\n#### Details\n\n * Method: `delete`\n * Path: `/v1/customers/{customer}/sources/{id}`\n"
     (
-      @spec delete(
+      @spec delete_source(
               customer :: binary(),
               id :: binary(),
               params :: %{optional(:expand) => list(binary)},
@@ -182,7 +194,7 @@ defmodule Stripe.Card do
               {:ok, Stripe.PaymentSource.t() | Stripe.DeletedPaymentSource.t()}
               | {:error, Stripe.ApiErrors.t()}
               | {:error, term()}
-      def delete(customer, id, params \\ %{}, opts \\ []) do
+      def delete_source(customer, id, params \\ %{}, opts \\ []) do
         path =
           Stripe.OpenApi.Path.replace_path_params(
             "/v1/customers/{customer}/sources/{id}",
@@ -220,6 +232,133 @@ defmodule Stripe.Card do
         Stripe.Request.new_request(opts)
         |> Stripe.Request.put_endpoint(path)
         |> Stripe.Request.put_params(params)
+        |> Stripe.Request.put_method(:delete)
+        |> Stripe.Request.make_request()
+      end
+    )
+  )
+
+  (
+    nil
+
+    @doc "<p>Updates the metadata, account holder name, account holder type of a bank account belonging to a <a href=\"/docs/connect/custom-accounts\">Custom account</a>, and optionally sets it as the default for its currency. Other bank account details are not editable by design.</p>\n\n<p>You can re-enable a disabled bank account by performing an update call without providing any arguments or changes.</p>\n\n#### Details\n\n * Method: `post`\n * Path: `/v1/accounts/{account}/external_accounts/{id}`\n"
+    (
+      @spec update_external_account(
+              account :: binary(),
+              id :: binary(),
+              params :: %{
+                optional(:account_holder_name) => binary,
+                optional(:account_holder_type) => :company | :individual,
+                optional(:account_type) => :checking | :futsu | :savings | :toza,
+                optional(:address_city) => binary,
+                optional(:address_country) => binary,
+                optional(:address_line1) => binary,
+                optional(:address_line2) => binary,
+                optional(:address_state) => binary,
+                optional(:address_zip) => binary,
+                optional(:default_for_currency) => boolean,
+                optional(:documents) => documents,
+                optional(:exp_month) => binary,
+                optional(:exp_year) => binary,
+                optional(:expand) => list(binary),
+                optional(:metadata) => %{optional(binary) => binary} | binary,
+                optional(:name) => binary
+              },
+              opts :: Keyword.t()
+            ) ::
+              {:ok, Stripe.ExternalAccount.t()}
+              | {:error, Stripe.ApiErrors.t()}
+              | {:error, term()}
+      def update_external_account(account, id, params \\ %{}, opts \\ []) do
+        path =
+          Stripe.OpenApi.Path.replace_path_params(
+            "/v1/accounts/{account}/external_accounts/{id}",
+            [
+              %OpenApiGen.Blueprint.Parameter{
+                in: "path",
+                name: "account",
+                required: true,
+                schema: %OpenApiGen.Blueprint.Parameter.Schema{
+                  name: "account",
+                  title: nil,
+                  type: "string",
+                  items: [],
+                  properties: [],
+                  any_of: []
+                }
+              },
+              %OpenApiGen.Blueprint.Parameter{
+                in: "path",
+                name: "id",
+                required: true,
+                schema: %OpenApiGen.Blueprint.Parameter.Schema{
+                  name: "id",
+                  title: nil,
+                  type: "string",
+                  items: [],
+                  properties: [],
+                  any_of: []
+                }
+              }
+            ],
+            [account, id]
+          )
+
+        Stripe.Request.new_request(opts)
+        |> Stripe.Request.put_endpoint(path)
+        |> Stripe.Request.put_params(params)
+        |> Stripe.Request.put_method(:post)
+        |> Stripe.Request.make_request()
+      end
+    )
+  )
+
+  (
+    nil
+
+    @doc "<p>Delete a specified external account for a given account.</p>\n\n#### Details\n\n * Method: `delete`\n * Path: `/v1/accounts/{account}/external_accounts/{id}`\n"
+    (
+      @spec delete_external_account(account :: binary(), id :: binary(), opts :: Keyword.t()) ::
+              {:ok, Stripe.DeletedExternalAccount.t()}
+              | {:error, Stripe.ApiErrors.t()}
+              | {:error, term()}
+      def delete_external_account(account, id, opts \\ []) do
+        path =
+          Stripe.OpenApi.Path.replace_path_params(
+            "/v1/accounts/{account}/external_accounts/{id}",
+            [
+              %OpenApiGen.Blueprint.Parameter{
+                in: "path",
+                name: "account",
+                required: true,
+                schema: %OpenApiGen.Blueprint.Parameter.Schema{
+                  name: "account",
+                  title: nil,
+                  type: "string",
+                  items: [],
+                  properties: [],
+                  any_of: []
+                }
+              },
+              %OpenApiGen.Blueprint.Parameter{
+                in: "path",
+                name: "id",
+                required: true,
+                schema: %OpenApiGen.Blueprint.Parameter.Schema{
+                  name: "id",
+                  title: nil,
+                  type: "string",
+                  items: [],
+                  properties: [],
+                  any_of: []
+                }
+              }
+            ],
+            [account, id]
+          )
+
+        Stripe.Request.new_request(opts)
+        |> Stripe.Request.put_endpoint(path)
         |> Stripe.Request.put_method(:delete)
         |> Stripe.Request.make_request()
       end

--- a/lib/generated/payment_intent.ex
+++ b/lib/generated/payment_intent.ex
@@ -92,16 +92,16 @@ defmodule Stripe.PaymentIntent do
   )
 
   (
-    @typedoc nil
+    @typedoc "If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method."
     @type acss_debit :: %{
-            optional(:mandate_options) => mandate_options,
-            optional(:setup_future_usage) => :none | :off_session | :on_session,
-            optional(:verification_method) => :automatic | :instant | :microdeposits
+            optional(:account_number) => binary,
+            optional(:institution_number) => binary,
+            optional(:transit_number) => binary
           }
   )
 
   (
-    @typedoc nil
+    @typedoc "Shipping address."
     @type address :: %{
             optional(:city) => binary,
             optional(:country) => binary,
@@ -192,11 +192,8 @@ defmodule Stripe.PaymentIntent do
   )
 
   (
-    @typedoc nil
-    @type boleto :: %{
-            optional(:expires_after_days) => integer,
-            optional(:setup_future_usage) => :none | :off_session | :on_session
-          }
+    @typedoc "If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method."
+    @type boleto :: %{optional(:tax_id) => binary}
   )
 
   (
@@ -315,8 +312,33 @@ defmodule Stripe.PaymentIntent do
   )
 
   (
-    @typedoc nil
-    @type fpx :: %{optional(:setup_future_usage) => :none}
+    @typedoc "If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method."
+    @type fpx :: %{
+            optional(:account_holder_type) => :company | :individual,
+            optional(:bank) =>
+              :affin_bank
+              | :agrobank
+              | :alliance_bank
+              | :ambank
+              | :bank_islam
+              | :bank_muamalat
+              | :bank_of_china
+              | :bank_rakyat
+              | :bsn
+              | :cimb
+              | :deutsche_bank
+              | :hong_leong_bank
+              | :hsbc
+              | :kfh
+              | :maybank2e
+              | :maybank2u
+              | :ocbc
+              | :pb_enterprise
+              | :public_bank
+              | :rhb
+              | :standard_chartered
+              | :uob
+          }
   )
 
   (
@@ -330,25 +352,8 @@ defmodule Stripe.PaymentIntent do
   )
 
   (
-    @typedoc "If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method."
-    @type ideal :: %{
-            optional(:bank) =>
-              :abn_amro
-              | :asn_bank
-              | :bunq
-              | :handelsbanken
-              | :ing
-              | :knab
-              | :moneyou
-              | :n26
-              | :rabobank
-              | :regiobank
-              | :revolut
-              | :sns_bank
-              | :triodos_bank
-              | :van_lanschot
-              | :yoursafe
-          }
+    @typedoc nil
+    @type ideal :: %{optional(:setup_future_usage) => :none | :off_session}
   )
 
   (
@@ -435,18 +440,8 @@ defmodule Stripe.PaymentIntent do
   )
 
   (
-    @typedoc "Configuration options for setting up an eMandate for cards issued in India."
-    @type mandate_options :: %{
-            optional(:amount) => integer,
-            optional(:amount_type) => :fixed | :maximum,
-            optional(:description) => binary,
-            optional(:end_date) => integer,
-            optional(:interval) => :day | :month | :sporadic | :week | :year,
-            optional(:interval_count) => integer,
-            optional(:reference) => binary,
-            optional(:start_date) => integer,
-            optional(:supported_types) => list(:india)
-          }
+    @typedoc "Additional fields for Mandate creation"
+    @type mandate_options :: %{optional(:collection_method) => :paper}
   )
 
   (
@@ -473,10 +468,34 @@ defmodule Stripe.PaymentIntent do
   )
 
   (
-    @typedoc nil
+    @typedoc "If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method."
     @type p24 :: %{
-            optional(:setup_future_usage) => :none,
-            optional(:tos_shown_and_accepted) => boolean
+            optional(:bank) =>
+              :alior_bank
+              | :bank_millennium
+              | :bank_nowy_bfg_sa
+              | :bank_pekao_sa
+              | :banki_spbdzielcze
+              | :blik
+              | :bnp_paribas
+              | :boz
+              | :citi_handlowy
+              | :credit_agricole
+              | :envelobank
+              | :etransfer_pocztowy24
+              | :getin_bank
+              | :ideabank
+              | :ing
+              | :inteligo
+              | :mbank_mtransfer
+              | :nest_przelew
+              | :noble_pay
+              | :pbac_z_ipko
+              | :plus_bank
+              | :santander_przelew24
+              | :tmobile_usbugi_bankowe
+              | :toyota_bank
+              | :volkswagen_bank
           }
   )
 

--- a/lib/generated/refund.ex
+++ b/lib/generated/refund.ex
@@ -52,16 +52,28 @@ defmodule Stripe.Refund do
   )
 
   (
+    @typedoc nil
+    @type created :: %{
+            optional(:gt) => integer,
+            optional(:gte) => integer,
+            optional(:lt) => integer,
+            optional(:lte) => integer
+          }
+  )
+
+  (
     nil
 
-    @doc "<p>You can see a list of the refunds belonging to a specific charge. Note that the 10 most recent refunds are always available by default on the charge object. If you need more than those 10, you can use this API method and the <code>limit</code> and <code>starting_after</code> parameters to page through additional refunds.</p>\n\n#### Details\n\n * Method: `get`\n * Path: `/v1/charges/{charge}/refunds`\n"
+    @doc "<p>Returns a list of all refunds you created. We return the refunds in sorted order, with the most recent refunds appearing first The 10 most recent refunds are always available by default on the Charge object.</p>\n\n#### Details\n\n * Method: `get`\n * Path: `/v1/refunds`\n"
     (
       @spec list(
-              charge :: binary(),
               params :: %{
+                optional(:charge) => binary,
+                optional(:created) => created | integer,
                 optional(:ending_before) => binary,
                 optional(:expand) => list(binary),
                 optional(:limit) => integer,
+                optional(:payment_intent) => binary,
                 optional(:starting_after) => binary
               },
               opts :: Keyword.t()
@@ -69,82 +81,8 @@ defmodule Stripe.Refund do
               {:ok, Stripe.List.t(Stripe.Refund.t())}
               | {:error, Stripe.ApiErrors.t()}
               | {:error, term()}
-      def list(charge, params \\ %{}, opts \\ []) do
-        path =
-          Stripe.OpenApi.Path.replace_path_params(
-            "/v1/charges/{charge}/refunds",
-            [
-              %OpenApiGen.Blueprint.Parameter{
-                in: "path",
-                name: "charge",
-                required: true,
-                schema: %OpenApiGen.Blueprint.Parameter.Schema{
-                  name: "charge",
-                  title: nil,
-                  type: "string",
-                  items: [],
-                  properties: [],
-                  any_of: []
-                }
-              }
-            ],
-            [charge]
-          )
-
-        Stripe.Request.new_request(opts)
-        |> Stripe.Request.put_endpoint(path)
-        |> Stripe.Request.put_params(params)
-        |> Stripe.Request.put_method(:get)
-        |> Stripe.Request.make_request()
-      end
-    )
-  )
-
-  (
-    nil
-
-    @doc "<p>Retrieves the details of an existing refund.</p>\n\n#### Details\n\n * Method: `get`\n * Path: `/v1/charges/{charge}/refunds/{refund}`\n"
-    (
-      @spec retrieve(
-              charge :: binary(),
-              refund :: binary(),
-              params :: %{optional(:expand) => list(binary)},
-              opts :: Keyword.t()
-            ) :: {:ok, Stripe.Refund.t()} | {:error, Stripe.ApiErrors.t()} | {:error, term()}
-      def retrieve(charge, refund, params \\ %{}, opts \\ []) do
-        path =
-          Stripe.OpenApi.Path.replace_path_params(
-            "/v1/charges/{charge}/refunds/{refund}",
-            [
-              %OpenApiGen.Blueprint.Parameter{
-                in: "path",
-                name: "charge",
-                required: true,
-                schema: %OpenApiGen.Blueprint.Parameter.Schema{
-                  name: "charge",
-                  title: nil,
-                  type: "string",
-                  items: [],
-                  properties: [],
-                  any_of: []
-                }
-              },
-              %OpenApiGen.Blueprint.Parameter{
-                in: "path",
-                name: "refund",
-                required: true,
-                schema: %OpenApiGen.Blueprint.Parameter.Schema{
-                  name: "refund",
-                  title: nil,
-                  type: "string",
-                  items: [],
-                  properties: [],
-                  any_of: []
-                }
-              }
-            ],
-            [charge, refund]
-          )
+      def list(params \\ %{}, opts \\ []) do
+        path = Stripe.OpenApi.Path.replace_path_params("/v1/refunds", [], [])
 
         Stripe.Request.new_request(opts)
         |> Stripe.Request.put_endpoint(path)
@@ -184,6 +122,47 @@ defmodule Stripe.Refund do
         |> Stripe.Request.put_endpoint(path)
         |> Stripe.Request.put_params(params)
         |> Stripe.Request.put_method(:post)
+        |> Stripe.Request.make_request()
+      end
+    )
+  )
+
+  (
+    nil
+
+    @doc "<p>Retrieves the details of an existing refund.</p>\n\n#### Details\n\n * Method: `get`\n * Path: `/v1/refunds/{refund}`\n"
+    (
+      @spec retrieve(
+              refund :: binary(),
+              params :: %{optional(:expand) => list(binary)},
+              opts :: Keyword.t()
+            ) :: {:ok, Stripe.Refund.t()} | {:error, Stripe.ApiErrors.t()} | {:error, term()}
+      def retrieve(refund, params \\ %{}, opts \\ []) do
+        path =
+          Stripe.OpenApi.Path.replace_path_params(
+            "/v1/refunds/{refund}",
+            [
+              %OpenApiGen.Blueprint.Parameter{
+                in: "path",
+                name: "refund",
+                required: true,
+                schema: %OpenApiGen.Blueprint.Parameter.Schema{
+                  name: "refund",
+                  title: nil,
+                  type: "string",
+                  items: [],
+                  properties: [],
+                  any_of: []
+                }
+              }
+            ],
+            [refund]
+          )
+
+        Stripe.Request.new_request(opts)
+        |> Stripe.Request.put_endpoint(path)
+        |> Stripe.Request.put_params(params)
+        |> Stripe.Request.put_method(:get)
         |> Stripe.Request.make_request()
       end
     )

--- a/lib/generated/token.ex
+++ b/lib/generated/token.ex
@@ -39,7 +39,7 @@ defmodule Stripe.Token do
   )
 
   (
-    @typedoc "The person's address."
+    @typedoc "The company's primary address."
     @type address :: %{
             optional(:city) => binary,
             optional(:country) => binary,
@@ -51,7 +51,7 @@ defmodule Stripe.Token do
   )
 
   (
-    @typedoc "The Kana variation of the the individual's primary address (Japan only)."
+    @typedoc "The Kana variation of the company's primary address (Japan only)."
     @type address_kana :: %{
             optional(:city) => binary,
             optional(:country) => binary,
@@ -64,7 +64,7 @@ defmodule Stripe.Token do
   )
 
   (
-    @typedoc "The Kanji variation of the person's address (Japan only)."
+    @typedoc "The Kanji variation of the the individual's primary address (Japan only)."
     @type address_kanji :: %{
             optional(:city) => binary,
             optional(:country) => binary,
@@ -268,7 +268,7 @@ defmodule Stripe.Token do
   )
 
   (
-    @typedoc "The individual's registered address."
+    @typedoc "The person's registered address."
     @type registered_address :: %{
             optional(:city) => binary,
             optional(:country) => binary,
@@ -293,8 +293,11 @@ defmodule Stripe.Token do
   )
 
   (
-    @typedoc "Information on the verification state of the company."
-    @type verification :: %{optional(:document) => document}
+    @typedoc "The person's verification status."
+    @type verification :: %{
+            optional(:additional_document) => additional_document,
+            optional(:document) => document
+          }
   )
 
   (

--- a/lib/openapi/phases/build_modules.ex
+++ b/lib/openapi/phases/build_modules.ex
@@ -1,9 +1,27 @@
 defmodule Stripe.OpenApi.Phases.BuildModules do
+  @method_name_overrides %{
+    ["Account"] => %{
+      {"retrieve", "/v1/account"} => "show",
+      {"retrieve", "/v1/accounts/{account}"} => "retrieve"
+    },
+    ["BankAccount"] => %{
+      {"delete", "/v1/customers/{customer}/sources/{id}"} => "delete_source",
+      {"delete", "/v1/accounts/{account}/external_accounts/{id}"} => "delete_external_account",
+      {"update", "/v1/customers/{customer}/sources/{id}"} => "update_source",
+      {"update", "/v1/accounts/{account}/external_accounts/{id}"} => "update_external_account"
+    },
+    ["Card"] => %{
+      {"delete", "/v1/customers/{customer}/sources/{id}"} => "delete_source",
+      {"delete", "/v1/accounts/{account}/external_accounts/{id}"} => "delete_external_account",
+      {"update", "/v1/customers/{customer}/sources/{id}"} => "update_source",
+      {"update", "/v1/accounts/{account}/external_accounts/{id}"} => "update_external_account"
+    }
+  }
+
   @moduledoc false
   def run(blueprint, _options \\ []) do
     components =
       for {name, map} <- blueprint.source["components"]["schemas"],
-          # map["x-stripeOperations"] != nil,
           map["x-resourceId"] != nil || name == "api_errors",
           into: %{} do
         resource =
@@ -15,9 +33,8 @@ defmodule Stripe.OpenApi.Phases.BuildModules do
            description: map["description"],
            operations:
              (map["x-stripeOperations"] || [])
-             # see connect/account_test.exs
-             |> Enum.uniq_by(& &1["method_name"])
-             |> Enum.map(&%{&1 | "method_name" => Macro.underscore(&1["method_name"])}),
+             |> Enum.reject(&(&1["method_on"] == "collection"))
+             |> Enum.map(&%{&1 | "method_name" => method_name(&1, resource)}),
            module: Module.concat(["Stripe" | resource]),
            properties: map["properties"] || %{},
            expandable_fields:
@@ -26,5 +43,12 @@ defmodule Stripe.OpenApi.Phases.BuildModules do
       end
 
     {:ok, %{blueprint | components: components}}
+  end
+
+  defp method_name(op, resource) do
+    case @method_name_overrides[resource][{op["method_name"], op["path"]}] do
+      nil -> Macro.underscore(op["method_name"])
+      value -> value
+    end
   end
 end

--- a/lib/openapi/phases/compile.ex
+++ b/lib/openapi/phases/compile.ex
@@ -1173,7 +1173,19 @@ defmodule Stripe.OpenApi.Phases.Compile do
     {"PostPlans", "/v1/plans", "create"} => "create",
     {"GetPlansPlan", "/v1/plans/{plan}", "retrieve"} => "retrieve",
     {"PostPlansPlan", "/v1/plans/{plan}", "update"} => "update",
-    {"DeletePlansPlan", "/v1/plans/{plan}", "delete"} => "delete"
+    {"DeletePlansPlan", "/v1/plans/{plan}", "delete"} => "delete",
+    {"PostCustomersCustomerSourcesId", "/v1/customers/{customer}/sources/{id}", "update_source"} =>
+      "update_source",
+    {"DeleteCustomersCustomerSourcesId", "/v1/customers/{customer}/sources/{id}", "delete_source"} =>
+      "delete_source",
+    {"PostAccountsAccountExternalAccountsId", "/v1/accounts/{account}/external_accounts/{id}",
+     "update_external_account"} => "update_external_account",
+    {"DeleteAccountsAccountExternalAccountsId", "/v1/accounts/{account}/external_accounts/{id}",
+     "delete_external_account"} => "delete_external_account",
+    {"GetRefunds", "/v1/refunds", "list"} => "list",
+    {"GetRefundsRefund", "/v1/refunds/{refund}", "retrieve"} => "retrieve",
+    {"GetAccount", "/v1/account", "show"} => "show",
+    {"GetAccountsAccount", "/v1/accounts/{account}", "retrieve"} => "retrieve"
   }
 
   defp to_func_name(operation, stripe_extension) do

--- a/test/stripe/connect/account_test.exs
+++ b/test/stripe/connect/account_test.exs
@@ -2,15 +2,14 @@ defmodule Stripe.AccountTest do
   use Stripe.StripeCase, async: true
 
   test "is retrievable using singular endpoint" do
-    assert {:ok, %Stripe.Account{}} = Stripe.Account.retrieve()
+    assert {:ok, %Stripe.Account{}} = Stripe.Account.show()
     assert_stripe_requested(:get, "/v1/account")
   end
 
-  # ellided by build_modules.ex > Enum.uniq_by(& &1["method_name"])
-  # test "is retrievable using plural endpoint" do
-  #   assert {:ok, %Stripe.Account{}} = Stripe.Account.retrieve("acct_123")
-  #   assert_stripe_requested(:get, "/v1/accounts/acct_123")
-  # end
+  test "is retrievable using plural endpoint" do
+    assert {:ok, %Stripe.Account{}} = Stripe.Account.retrieve("acct_123")
+    assert_stripe_requested(:get, "/v1/accounts/acct_123")
+  end
 
   test "is creatable" do
     assert {:ok, %Stripe.Account{}} = Stripe.Account.create(%{metadata: %{}, type: "standard"})

--- a/test/stripe/core_resources/refund_test.exs
+++ b/test/stripe/core_resources/refund_test.exs
@@ -2,25 +2,16 @@ defmodule Stripe.RefundTest do
   use Stripe.StripeCase, async: true
 
   test "charge refunds is listable" do
-    assert {:ok, %Stripe.List{data: refunds}} = Stripe.Refund.list("ab123")
-    assert_stripe_requested(:get, "/v1/charges/ab123/refunds")
+    assert {:ok, %Stripe.List{data: refunds}} = Stripe.Refund.list(%{charge: "ab123"})
+    assert_stripe_requested(:get, "/v1/refunds?charge=ab123")
     assert is_list(refunds)
     assert %Stripe.Refund{} = hd(refunds)
   end
 
   test "charge refund is retrievable" do
-    assert {:ok, %Stripe.Refund{}} = Stripe.Refund.retrieve("ch123", "re_123")
-    assert_stripe_requested(:get, "/v1/charges/ch123/refunds/re_123")
+    assert {:ok, %Stripe.Refund{}} = Stripe.Refund.retrieve("re123")
+    assert_stripe_requested(:get, "/v1/refunds/re123")
   end
-
-  # @tag :skip
-  # test "refund is retrievable" do
-  #   # /v1/refunds/{refund}" && /v1/charges/{charge}/refunds/{refund}"
-  #   # IO.inspect Stripe.Refund.__info__(:functions)
-  #  TODO: retrieve_refund doesn't exist
-  #   assert {:ok, %Stripe.Refund{}} = Stripe.Refund.retrieve_refund("re_123")
-  #   assert_stripe_requested(:get, "/v1/refunds/re_123")
-  # end
 
   test "is creatable" do
     assert {:ok, %Stripe.Refund{}} = Stripe.Refund.create(%{charge: "ch_123"})

--- a/test/stripe/payment_methods/bank_account_test.exs
+++ b/test/stripe/payment_methods/bank_account_test.exs
@@ -3,14 +3,14 @@ defmodule Stripe.BankAccountTest do
 
   describe "update/2" do
     test "updates a bank account" do
-      assert {:ok, _} = Stripe.BankAccount.update("cus_123", "ba_123")
+      assert {:ok, _} = Stripe.BankAccount.update_source("cus_123", "ba_123")
       assert_stripe_requested(:post, "/v1/customers/cus_123/sources/ba_123")
     end
   end
 
   describe "delete/2" do
     test "deletes a bank account" do
-      assert {:ok, _} = Stripe.BankAccount.delete("cus_123", "ba_123")
+      assert {:ok, _} = Stripe.BankAccount.delete_source("cus_123", "ba_123")
       assert_stripe_requested(:delete, "/v1/customers/cus_123/sources/ba_123")
     end
   end

--- a/test/stripe/payment_methods/card_test.exs
+++ b/test/stripe/payment_methods/card_test.exs
@@ -6,25 +6,30 @@ defmodule Stripe.CardTest do
              {:__from_json__, 1},
              {:__struct__, 0},
              {:__struct__, 1},
-             delete: 2,
-             delete: 3,
-             delete: 4,
-             update: 2,
-             update: 3,
-             update: 4
+             {:delete_external_account, 2},
+             {:delete_external_account, 3},
+             {:delete_source, 2},
+             {:delete_source, 3},
+             {:delete_source, 4},
+             {:update_external_account, 2},
+             {:update_external_account, 3},
+             {:update_external_account, 4},
+             {:update_source, 2},
+             {:update_source, 3},
+             {:update_source, 4}
            ] = Stripe.Card.__info__(:functions)
   end
 
   describe "update/2" do
     test "updates a card" do
-      assert {:ok, _} = Stripe.Card.update("cus_123", "card_123", %{name: "sco"})
+      assert {:ok, _} = Stripe.Card.update_source("cus_123", "card_123", %{name: "sco"})
       assert_stripe_requested(:post, "/v1/customers/cus_123/sources/card_123")
     end
   end
 
   describe "delete/2" do
     test "deletes a card" do
-      assert {:ok, _} = Stripe.Card.delete("cus_123", "card_123")
+      assert {:ok, _} = Stripe.Card.delete_source("cus_123", "card_123")
       assert_stripe_requested(:delete, "/v1/customers/cus_123/sources/card_123")
     end
   end


### PR DESCRIPTION
This commit runs `make run-all` which updates to latest spec and, fix the Account's ID using an overrides approach introduced by this PR:

https://github.com/beam-community/stripity-stripe/pull/786

Once that PR gets merged to the upstream, we should be able to use the upstream master in our Dice main repo.