### PR TITLE
chore: ignore ci.yaml from common-config sync

### DIFF
--- a/.github/common-config.yaml
+++ b/.github/common-config.yaml
@@ -1,4 +1,5 @@
 ignore-files:
   - .github/common-config.yaml # Ignore this file itself
+  - .github/workflows/ci.yaml
   - .formatter.exs
   - .credo.exs


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yaml` to the `ignore-files` list in `.github/common-config.yaml` so the beam-community common-config sync workflow no longer overwrites this repo's custom CI configuration.

Closes the issue introduced by the automated change in #887.

## Test Steps

1. Merge this PR.
2. Confirm that the next common-config sync run does **not** open a PR modifying `.github/workflows/ci.yaml`.

## Checklist

- [x] No tests needed — config-only change
- [ ] Documentation updated (if applicable)