### PR TITLE
feat: add response_as option for flexible Stripe response formatting

### DIFF
--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -35,7 +35,7 @@ defmodule Stripe do
       duplicate requests to the stripe API. See [https://stripe.com/docs/api/idempotent_requests](https://stripe.com/docs/api/idempotent_requests)
     * `:response_as_json` - If set to `true`, the response will be returned as a
     JSON string instead of a struct. This is useful for persisting the original
-    response from stripe. You can use Stripe.Converter.convert_result/1 to structs
+    response from stripe. You can use Stripe.Converter.convert_result/1 to get structs
     from it.
 
   ### HTTP Connection Pool

--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -33,6 +33,10 @@ defmodule Stripe do
       from Stripe. See [https://stripe.com/docs/api/expanding_objects](https://stripe.com/docs/api/expanding_objects)
     * `:idempotency_key` - A string that is passed through as the "Idempotency-Key" header on all POST requests. This is used by Stripe's idempotency layer to manage
       duplicate requests to the stripe API. See [https://stripe.com/docs/api/idempotent_requests](https://stripe.com/docs/api/idempotent_requests)
+    * `:response_as_json` - If set to `true`, the response will be returned as a
+    JSON string instead of a struct. This is useful for persisting the original
+    response from stripe. You can use Stripe.Converter.convert_result/1 to structs
+    from it.
 
   ### HTTP Connection Pool
 

--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -33,10 +33,12 @@ defmodule Stripe do
       from Stripe. See [https://stripe.com/docs/api/expanding_objects](https://stripe.com/docs/api/expanding_objects)
     * `:idempotency_key` - A string that is passed through as the "Idempotency-Key" header on all POST requests. This is used by Stripe's idempotency layer to manage
       duplicate requests to the stripe API. See [https://stripe.com/docs/api/idempotent_requests](https://stripe.com/docs/api/idempotent_requests)
-    * `:response_as_json` - If set to `true`, the response will be returned as a
-    JSON string instead of a struct. This is useful for persisting the original
-    response from stripe. You can use Stripe.Converter.convert_result/1 to get structs
-    from it.
+    * `:response_as` - Controls the format of the response. Accepts `:struct`
+      (default), `:map`, or `:raw`. `:struct` converts the response into typed
+      Stripe structs. `:map` returns the decoded response as a plain map with
+      string keys, useful for serializing and storing the response; later you can
+      convert it back with `Stripe.Converter.convert_result/1`. `:raw` returns
+      the raw JSON string.
 
   ### HTTP Connection Pool
 
@@ -83,6 +85,7 @@ defmodule Stripe do
           optional(:lte) => integer
         }
   @type options :: Keyword.t()
+  @type response_as :: :struct | :map | :raw
   @type timestamp :: pos_integer
 
   @doc """

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -201,7 +201,11 @@ defmodule Stripe.Request do
     with {:ok, params} <- do_cast_to_id(params, request.cast_to_id),
          {:ok, endpoint} <- consolidate_endpoint(endpoint, params),
          {:ok, result} <- API.request(params, method, endpoint, headers, opts) do
-      {:ok, Converter.convert_result(result)}
+      if Keyword.get(opts, :response_as_json, false) do
+        {:ok, result}
+      else
+        {:ok, Converter.convert_result(result)}
+      end
     end
   end
 
@@ -213,7 +217,11 @@ defmodule Stripe.Request do
     with {:ok, params} <- do_cast_to_id(params, request.cast_to_id),
          {:ok, endpoint} <- consolidate_endpoint(endpoint, params),
          {:ok, result} <- API.request_file_upload(params, method, endpoint, %{}, opts) do
-      {:ok, Converter.convert_result(result)}
+      if Keyword.get(opts, :response_as_json, false) do
+        {:ok, result}
+      else
+        {:ok, Converter.convert_result(result)}
+      end
     end
   end
 

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -193,7 +193,7 @@ defmodule Stripe.Request do
   @doc """
   Executes the request and returns the response.
   """
-  @spec make_request(t) :: {:ok, struct} | {:error, Stripe.Error.t()}
+  @spec make_request(t) :: {:ok, struct() | map() | String.t()} | {:error, Stripe.Error.t()}
   def make_request(
         %Request{params: params, endpoint: endpoint, method: method, headers: headers, opts: opts} =
           request
@@ -208,7 +208,7 @@ defmodule Stripe.Request do
   @doc """
   Executes the request and returns the response for file uploads
   """
-  @spec make_file_upload_request(t) :: {:ok, struct} | {:error, Stripe.Error.t()}
+  @spec make_file_upload_request(t) :: {:ok, struct() | map() | String.t()} | {:error, Stripe.Error.t()}
   def make_file_upload_request(%Request{params: params, endpoint: endpoint, method: method, opts: opts} = request) do
     with {:ok, params} <- do_cast_to_id(params, request.cast_to_id),
          {:ok, endpoint} <- consolidate_endpoint(endpoint, params),

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -219,7 +219,9 @@ defmodule Stripe.Request do
 
   defp format_response(result, :struct), do: Converter.convert_result(result)
   defp format_response(result, :map), do: result
-  defp format_response(result, :raw), do: Stripe.API.json_library().encode!(result)
+
+  defp format_response(result, :raw),
+    do: result |> Stripe.API.json_library().encode!() |> IO.iodata_to_binary()
 
   defp do_cast_to_id(params, cast_to_id) do
     to_cast = MapSet.to_list(cast_to_id)

--- a/lib/stripe/request.ex
+++ b/lib/stripe/request.ex
@@ -201,11 +201,7 @@ defmodule Stripe.Request do
     with {:ok, params} <- do_cast_to_id(params, request.cast_to_id),
          {:ok, endpoint} <- consolidate_endpoint(endpoint, params),
          {:ok, result} <- API.request(params, method, endpoint, headers, opts) do
-      if Keyword.get(opts, :response_as_json, false) do
-        {:ok, result}
-      else
-        {:ok, Converter.convert_result(result)}
-      end
+      {:ok, format_response(result, Keyword.get(opts, :response_as, :struct))}
     end
   end
 
@@ -217,13 +213,13 @@ defmodule Stripe.Request do
     with {:ok, params} <- do_cast_to_id(params, request.cast_to_id),
          {:ok, endpoint} <- consolidate_endpoint(endpoint, params),
          {:ok, result} <- API.request_file_upload(params, method, endpoint, %{}, opts) do
-      if Keyword.get(opts, :response_as_json, false) do
-        {:ok, result}
-      else
-        {:ok, Converter.convert_result(result)}
-      end
+      {:ok, format_response(result, Keyword.get(opts, :response_as, :struct))}
     end
   end
+
+  defp format_response(result, :struct), do: Converter.convert_result(result)
+  defp format_response(result, :map), do: result
+  defp format_response(result, :raw), do: Stripe.API.json_library().encode!(result)
 
   defp do_cast_to_id(params, cast_to_id) do
     to_cast = MapSet.to_list(cast_to_id)

--- a/lib/stripe/webhook.ex
+++ b/lib/stripe/webhook.ex
@@ -37,9 +37,20 @@ defmodule Stripe.Webhook do
           # Reject webhook by responding with non-2XX
       end
   """
-  @spec construct_event(String.t(), String.t(), String.t(), integer, opts :: Keyword.t()) ::
-          {:ok, Stripe.Event.t()} | {:error, any}
-  def construct_event(payload, signature_header, secret, tolerance \\ @default_tolerance, opts \\ []) do
+  @spec construct_event(
+          String.t(),
+          String.t(),
+          String.t(),
+          integer | Keyword.t(),
+          Keyword.t()
+        ) :: {:ok, Stripe.Event.t() | map() | String.t()} | {:error, any}
+  def construct_event(payload, signature_header, secret, tolerance_or_opts \\ @default_tolerance, opts \\ [])
+
+  def construct_event(payload, signature_header, secret, opts, []) when is_list(opts) do
+    construct_event(payload, signature_header, secret, @default_tolerance, opts)
+  end
+
+  def construct_event(payload, signature_header, secret, tolerance, opts) when is_integer(tolerance) do
     case verify_header(payload, signature_header, secret, tolerance) do
       :ok -> {:ok, format_response(payload, Keyword.get(opts, :response_as, :struct))}
       error -> error

--- a/lib/stripe/webhook.ex
+++ b/lib/stripe/webhook.ex
@@ -41,16 +41,14 @@ defmodule Stripe.Webhook do
           {:ok, Stripe.Event.t()} | {:error, any}
   def construct_event(payload, signature_header, secret, tolerance \\ @default_tolerance, opts \\ []) do
     case verify_header(payload, signature_header, secret, tolerance) do
-      :ok ->
-        if Keyword.get(opts, :response_as_json, false) do
-          {:ok, convert_to_json!(payload)}
-        else
-          {:ok, convert_to_event!(payload)}
-        end
-      error ->
-        error
+      :ok -> {:ok, format_response(payload, Keyword.get(opts, :response_as, :struct))}
+      error -> error
     end
   end
+
+  defp format_response(payload, :struct), do: convert_to_event!(payload)
+  defp format_response(payload, :map), do: convert_to_map!(payload)
+  defp format_response(payload, :raw), do: payload
 
   defp verify_header(payload, signature_header, secret, tolerance) do
     case get_timestamp_and_signatures(signature_header, @expected_scheme) do
@@ -149,11 +147,11 @@ defmodule Stripe.Webhook do
     |> secure_compare(input, expected)
   end
 
-  defp convert_to_json!(payload) do
+  defp convert_to_map!(payload) do
     payload |> Stripe.API.json_library().decode!()
   end
 
   defp convert_to_event!(payload) do
-    payload |> convert_to_json!() |> Stripe.Converter.convert_result()
+    payload |> convert_to_map!() |> Stripe.Converter.convert_result()
   end
 end

--- a/lib/stripe/webhook.ex
+++ b/lib/stripe/webhook.ex
@@ -22,6 +22,21 @@ defmodule Stripe.Webhook do
   `tolerance` is the allowed deviation in seconds from the current system time
   to the timestamp found in `signature`. Defaults to 300 seconds (5 minutes).
 
+  `opts` is a keyword list of options. Supported options:
+
+    * `:response_as` - controls the shape of the value returned in the `:ok`
+      tuple. One of:
+      * `:struct` (default) - returns a `Stripe.Event.t()`.
+      * `:map` - returns the decoded payload as a map with string keys (useful
+        when persisting webhooks for later replay or struct conversion via
+        `Stripe.Converter.convert_result/1`).
+      * `:raw` - returns the original `payload` string verbatim.
+
+  When `tolerance` is omitted, `opts` may be passed directly as the 4th
+  argument:
+
+      Stripe.Webhook.construct_event(payload, signature, secret, response_as: :map)
+
   Stripe API reference:
   https://stripe.com/docs/webhooks/signatures#verify-manually
 

--- a/lib/stripe/webhook.ex
+++ b/lib/stripe/webhook.ex
@@ -159,7 +159,7 @@ defmodule Stripe.Webhook do
   end
 
   defp convert_to_map!(payload) do
-    payload |> Stripe.API.json_library().decode!()
+    Stripe.API.json_library().decode!(payload)
   end
 
   defp convert_to_event!(payload) do

--- a/test/stripe/webhook_test.exs
+++ b/test/stripe/webhook_test.exs
@@ -35,6 +35,33 @@ defmodule Stripe.WebhookTest do
     assert {:ok, %Stripe.Event{}} = construct_event(payload, signature_header, @secret)
   end
 
+  test "payload with response_as: :struct returns a Stripe.Event struct" do
+    timestamp = System.system_time(:second)
+    signature = generate_signature(timestamp, @valid_payload)
+    signature_header = create_signature_header(timestamp, @valid_scheme, signature)
+
+    assert {:ok, %Stripe.Event{}} =
+             construct_event(@valid_payload, signature_header, @secret, 300, response_as: :struct)
+  end
+
+  test "payload with response_as: :map returns a plain map with string keys" do
+    timestamp = System.system_time(:second)
+    signature = generate_signature(timestamp, @valid_payload)
+    signature_header = create_signature_header(timestamp, @valid_scheme, signature)
+
+    assert {:ok, %{"object" => "event"}} =
+             construct_event(@valid_payload, signature_header, @secret, 300, response_as: :map)
+  end
+
+  test "payload with response_as: :raw returns the original payload string" do
+    timestamp = System.system_time(:second)
+    signature = generate_signature(timestamp, @valid_payload)
+    signature_header = create_signature_header(timestamp, @valid_scheme, signature)
+
+    assert {:ok, @valid_payload} =
+             construct_event(@valid_payload, signature_header, @secret, 300, response_as: :raw)
+  end
+
   test "payload with an invalid signature should fail" do
     timestamp = System.system_time(:second)
     payload = @valid_payload

--- a/test/stripe/webhook_test.exs
+++ b/test/stripe/webhook_test.exs
@@ -62,6 +62,15 @@ defmodule Stripe.WebhookTest do
              construct_event(@valid_payload, signature_header, @secret, 300, response_as: :raw)
   end
 
+  test "opts can be passed as the 4th argument when tolerance is omitted" do
+    timestamp = System.system_time(:second)
+    signature = generate_signature(timestamp, @valid_payload)
+    signature_header = create_signature_header(timestamp, @valid_scheme, signature)
+
+    assert {:ok, %{"object" => "event"}} =
+             construct_event(@valid_payload, signature_header, @secret, response_as: :map)
+  end
+
   test "payload with an invalid signature should fail" do
     timestamp = System.system_time(:second)
     payload = @valid_payload


### PR DESCRIPTION
## Summary

Picks up the abandoned work from #805 and incorporates the requested review feedback.

- Cherry-picked the two commits from @mindreader's PR (#805)
- Replaced the `response_as_json: true/false` boolean with a `response_as` enum per @yordis' review feedback
- Added `@type response_as :: :struct | :map | :raw` to `Stripe` for documentation and Dialyzer
- Covered all three variants with ExUnit tests on `Stripe.Webhook`

### The `response_as` option

| Value | Behaviour |
|-------|-----------|
| `:struct` (default) | Converts the response to typed Stripe structs — existing behaviour, fully backwards-compatible |
| `:map` | Returns the decoded response as a plain map with string keys; useful for persisting Stripe responses; convert back later with `Stripe.Converter.convert_result/1` |
| `:raw` | Returns the raw JSON string (original payload for webhooks; re-encoded JSON for API requests) |

### Motivation (from the original PR)

Users who persist Stripe responses to a database and later need to reconstruct structs were forced to write manual wrappers. With `:map`, they can store the decoded map (JSON-encodable, string-keyed), then reconstruct structs with `Stripe.Converter.convert_result/1` without caring about API version schema drift in the stored value.

## Test plan

- [x] All existing webhook tests still pass (`mix test test/stripe/webhook_test.exs`)  
- [x] New tests added for `:struct`, `:map`, and `:raw` on `Stripe.Webhook.construct_event/5`
- [x] Clean compile with no warnings (`mix compile --warnings-as-errors`)
- [x] `Stripe.Request.make_request/1` and `make_file_upload_request/1` updated with the same enum logic

Closes #805