### PR TITLE
feat: add rich telemetry metadata to API requests and webhook events

### DIFF
--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -213,6 +213,21 @@ defmodule Stripe.API do
     end
   end
 
+  @spec add_telemetry_metadata(list, map) :: list
+  defp add_telemetry_metadata(opts, args) do
+    parsed_uri = URI.parse(args.req_url)
+    api_version = args.req_headers["Stripe-Version"]
+
+    Keyword.put(opts, :telemetry_metadata, %{
+      stripe_api_endpoint: parsed_uri.path,
+      stripe_api_version: api_version,
+      http_method: args.method,
+      http_retry_count: 0,
+      http_status_code: nil,
+      http_url: URI.to_string(%{parsed_uri | query: nil})
+    })
+  end
+
   @doc """
   A low level utility function to make a direct request to the Stripe API
 
@@ -346,6 +361,11 @@ defmodule Stripe.API do
       |> add_default_options()
       |> add_pool_option()
       |> add_options_from_config()
+      |> add_telemetry_metadata(%{
+        method: method,
+        req_headers: req_headers,
+        req_url: req_url
+      })
 
     do_perform_request(method, req_url, req_headers, body, req_opts)
   end
@@ -369,16 +389,16 @@ defmodule Stripe.API do
   end
 
   defp do_perform_request_and_retry(method, url, headers, body, opts, {:attempts, attempts}) do
-    start_metadata = %{url: url, method: method, attempts: attempts, headers: headers}
+    telemetry_meta = Keyword.get(opts, :telemetry_metadata, %{})
 
     response =
-      :telemetry.span(~w[stripe request]a, start_metadata, fn ->
+      :telemetry.span(~w[stripe request]a, telemetry_meta, fn ->
         case http_module().request(method, url, Map.to_list(headers), body, opts) do
           {:ok, status, _, _} = resp ->
-            {resp, Map.merge(start_metadata, %{status: status})}
+            {resp, Map.merge(telemetry_meta, %{http_status_code: status, http_retry_count: attempts})}
 
           error ->
-            {error, %{}}
+            {error, telemetry_meta}
         end
       end)
 

--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -389,13 +389,16 @@ defmodule Stripe.API do
   end
 
   defp do_perform_request_and_retry(method, url, headers, body, opts, {:attempts, attempts}) do
-    telemetry_meta = Keyword.get(opts, :telemetry_metadata, %{})
+    telemetry_meta =
+      opts
+      |> Keyword.get(:telemetry_metadata, %{})
+      |> Map.put(:http_retry_count, attempts)
 
     response =
       :telemetry.span(~w[stripe request]a, telemetry_meta, fn ->
         case http_module().request(method, url, Map.to_list(headers), body, opts) do
           {:ok, status, _, _} = resp ->
-            {resp, Map.merge(telemetry_meta, %{http_status_code: status, http_retry_count: attempts})}
+            {resp, Map.put(telemetry_meta, :http_status_code, status)}
 
           error ->
             {error, telemetry_meta}

--- a/lib/stripe/webhook_plug.ex
+++ b/lib/stripe/webhook_plug.ex
@@ -159,30 +159,40 @@ if Code.ensure_loaded?(Plug) do
     end
 
     defp handle_event!(handler, %Stripe.Event{} = event) do
-      case handler.handle_event(event) do
-        {:ok, _} ->
-          :ok
+      telemetry_meta = %{event: event.type, handler_status: nil}
 
-        :ok ->
-          :ok
+      :telemetry.span(~w[stripe webhook]a, telemetry_meta, fn ->
+        handler_result =
+          case handler.handle_event(event) do
+            {:ok, _} ->
+              :ok
 
-        {:error, reason} when is_binary(reason) ->
-          {:handle_error, reason}
+            :ok ->
+              :ok
 
-        {:error, reason} when is_atom(reason) ->
-          {:handle_error, Atom.to_string(reason)}
+            {:error, reason} when is_binary(reason) ->
+              {:handle_error, reason}
 
-        :error ->
-          {:handle_error, ""}
+            {:error, reason} when is_atom(reason) ->
+              {:handle_error, Atom.to_string(reason)}
 
-        resp ->
-          raise """
-          #{inspect(handler)}.handle_event/1 returned an invalid response. Expected {:ok, term}, :ok, {:error, reason} or :error
-          Got: #{inspect(resp)}
+            :error ->
+              {:handle_error, ""}
 
-          Event data: #{inspect(event)}
-          """
-      end
+            resp ->
+              raise """
+              #{inspect(handler)}.handle_event/1 returned an invalid response. Expected {:ok, term}, :ok, {:error, reason} or :error
+              Got: #{inspect(resp)}
+
+              Event data: #{inspect(event)}
+              """
+          end
+
+        then(handler_result, fn
+          :ok -> {:ok, %{telemetry_meta | handler_status: :ok}}
+          result -> {result, %{telemetry_meta | handler_status: :error}}
+        end)
+      end)
     end
 
     defp parse_secret!({m, f, a}), do: apply(m, f, a)

--- a/lib/stripe/webhook_plug.ex
+++ b/lib/stripe/webhook_plug.ex
@@ -162,36 +162,30 @@ if Code.ensure_loaded?(Plug) do
       telemetry_meta = %{event: event.type, handler_status: nil}
 
       :telemetry.span(~w[stripe webhook]a, telemetry_meta, fn ->
-        handler_result =
-          case handler.handle_event(event) do
-            {:ok, _} ->
-              :ok
+        case handler.handle_event(event) do
+          {:ok, _} ->
+            {:ok, %{telemetry_meta | handler_status: :ok}}
 
-            :ok ->
-              :ok
+          :ok ->
+            {:ok, %{telemetry_meta | handler_status: :ok}}
 
-            {:error, reason} when is_binary(reason) ->
-              {:handle_error, reason}
+          {:error, reason} when is_binary(reason) ->
+            {{:handle_error, reason}, %{telemetry_meta | handler_status: :error}}
 
-            {:error, reason} when is_atom(reason) ->
-              {:handle_error, Atom.to_string(reason)}
+          {:error, reason} when is_atom(reason) ->
+            {{:handle_error, Atom.to_string(reason)}, %{telemetry_meta | handler_status: :error}}
 
-            :error ->
-              {:handle_error, ""}
+          :error ->
+            {{:handle_error, ""}, %{telemetry_meta | handler_status: :error}}
 
-            resp ->
-              raise """
-              #{inspect(handler)}.handle_event/1 returned an invalid response. Expected {:ok, term}, :ok, {:error, reason} or :error
-              Got: #{inspect(resp)}
+          resp ->
+            raise """
+            #{inspect(handler)}.handle_event/1 returned an invalid response. Expected {:ok, term}, :ok, {:error, reason} or :error
+            Got: #{inspect(resp)}
 
-              Event data: #{inspect(event)}
-              """
-          end
-
-        then(handler_result, fn
-          :ok -> {:ok, %{telemetry_meta | handler_status: :ok}}
-          result -> {result, %{telemetry_meta | handler_status: :error}}
-        end)
+            Event data: #{inspect(event)}
+            """
+        end
       end)
     end
 

--- a/test/stripe/api_test.exs
+++ b/test/stripe/api_test.exs
@@ -2,6 +2,10 @@ defmodule Stripe.APITest do
   use Stripe.StripeCase
   import Mox
 
+  def telemetry_handler_fn(name, measurements, metadata, _config) do
+    send(self(), {:telemetry_event, name, measurements, metadata})
+  end
+
   test "works with non existent responses without issue" do
     {:error, %Stripe.Error{extra: %{http_status: 404}}} =
       Stripe.API.request(%{}, :get, "/", %{}, [])
@@ -83,6 +87,44 @@ defmodule Stripe.APITest do
     test "given attempts = 2" do
       backoff = Stripe.API.backoff(2, base_backoff: 10, max_backoff: 100)
       assert backoff in 20..40
+    end
+  end
+
+  describe "telemetry" do
+    test "requests emit :start, :stop telemetry events", %{test: test} do
+      :telemetry.attach_many(
+        "#{test}",
+        [[:stripe, :request, :start], [:stripe, :request, :stop]],
+        &__MODULE__.telemetry_handler_fn/4,
+        nil
+      )
+
+      Stripe.API.request(%{query: ~s|email: "test@example.com"|}, :get, "/v1/customers/search", %{}, [])
+
+      assert_received({
+        :telemetry_event,
+        [:stripe, :request, :start],
+        %{monotonic_time: _},
+        %{telemetry_span_context: _}
+      })
+
+      assert_received({
+        :telemetry_event,
+        [:stripe, :request, :stop],
+        %{monotonic_time: _, duration: _},
+        %{
+          http_method: :get,
+          http_retry_count: 0,
+          http_status_code: 200,
+          http_url: http_url,
+          stripe_api_version: _,
+          stripe_api_endpoint: "/v1/customers/search",
+          telemetry_span_context: _
+        }
+      })
+
+      assert String.ends_with?(http_url, "/v1/customers/search")
+      assert not String.contains?(http_url, "test@example.com")
     end
   end
 

--- a/test/stripe/api_test.exs
+++ b/test/stripe/api_test.exs
@@ -92,12 +92,16 @@ defmodule Stripe.APITest do
 
   describe "telemetry" do
     test "requests emit :start, :stop telemetry events", %{test: test} do
+      handler_id = "#{test}"
+
       :telemetry.attach_many(
-        "#{test}",
+        handler_id,
         [[:stripe, :request, :start], [:stripe, :request, :stop]],
         &__MODULE__.telemetry_handler_fn/4,
         nil
       )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
 
       Stripe.API.request(%{query: ~s|email: "test@example.com"|}, :get, "/v1/customers/search", %{}, [])
 

--- a/test/stripe/webhook_plug_test.exs
+++ b/test/stripe/webhook_plug_test.exs
@@ -190,12 +190,16 @@ defmodule Stripe.WebhookPlugTest do
     end
 
     test "emits :start, :exception telemetry events on exception", %{conn: conn, test: test} do
+      handler_id = "#{test}"
+
       :telemetry.attach_many(
-        "#{test}",
+        handler_id,
         [[:stripe, :webhook, :start], [:stripe, :webhook, :exception]],
         &__MODULE__.telemetry_handler_fn/4,
         nil
       )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
 
       opts =
         WebhookPlug.init(
@@ -224,12 +228,16 @@ defmodule Stripe.WebhookPlugTest do
     end
 
     test "emits :start, :stop telemetry events on soft failure", %{conn: conn, test: test} do
+      handler_id = "#{test}"
+
       :telemetry.attach_many(
-        "#{test}",
+        handler_id,
         [[:stripe, :webhook, :start], [:stripe, :webhook, :stop]],
         &__MODULE__.telemetry_handler_fn/4,
         nil
       )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
 
       opts =
         WebhookPlug.init(
@@ -256,12 +264,16 @@ defmodule Stripe.WebhookPlugTest do
     end
 
     test "emits :start, :stop telemetry events on success", %{conn: conn, test: test} do
+      handler_id = "#{test}"
+
       :telemetry.attach_many(
-        "#{test}",
+        handler_id,
         [[:stripe, :webhook, :start], [:stripe, :webhook, :stop]],
         &__MODULE__.telemetry_handler_fn/4,
         nil
       )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
 
       WebhookPlug.call(conn, @opts)
 

--- a/test/stripe/webhook_plug_test.exs
+++ b/test/stripe/webhook_plug_test.exs
@@ -3,7 +3,7 @@ defmodule Stripe.WebhookPlugTest do
   use Plug.Test
   alias Stripe.WebhookPlug
 
-  @valid_payload ~S({"object": "event"})
+  @valid_payload ~S({"object": "event", "type": "customer.updated"})
   @secret "secret"
 
   @opts WebhookPlug.init(
@@ -45,6 +45,10 @@ defmodule Stripe.WebhookPlugTest do
   end
 
   def get_value(:secret), do: @secret
+
+  def telemetry_handler_fn(name, measurements, metadata, _config) do
+    send(self(), {:telemetry_event, name, measurements, metadata})
+  end
 
   defp generate_signature_header(payload) do
     timestamp = System.system_time(:second)
@@ -183,6 +187,97 @@ defmodule Stripe.WebhookPlugTest do
       assert_raise RuntimeError, fn ->
         WebhookPlug.call(conn, opts)
       end
+    end
+
+    test "emits :start, :exception telemetry events on exception", %{conn: conn, test: test} do
+      :telemetry.attach_many(
+        "#{test}",
+        [[:stripe, :webhook, :start], [:stripe, :webhook, :exception]],
+        &__MODULE__.telemetry_handler_fn/4,
+        nil
+      )
+
+      opts =
+        WebhookPlug.init(
+          at: "/webhook/stripe",
+          handler: __MODULE__.BadHandler,
+          secret: @secret
+        )
+
+      assert_raise RuntimeError, fn ->
+        WebhookPlug.call(conn, opts)
+      end
+
+      assert_received({
+        :telemetry_event,
+        [:stripe, :webhook, :start],
+        %{monotonic_time: _},
+        %{telemetry_span_context: _}
+      })
+
+      assert_received({
+        :telemetry_event,
+        [:stripe, :webhook, :exception],
+        %{monotonic_time: _, duration: _},
+        %{kind: _, reason: _, stacktrace: _, telemetry_span_context: _, event: "customer.updated"}
+      })
+    end
+
+    test "emits :start, :stop telemetry events on soft failure", %{conn: conn, test: test} do
+      :telemetry.attach_many(
+        "#{test}",
+        [[:stripe, :webhook, :start], [:stripe, :webhook, :stop]],
+        &__MODULE__.telemetry_handler_fn/4,
+        nil
+      )
+
+      opts =
+        WebhookPlug.init(
+          at: "/webhook/stripe",
+          handler: __MODULE__.ErrorTupleAtomHandler,
+          secret: @secret
+        )
+
+      WebhookPlug.call(conn, opts)
+
+      assert_received({
+        :telemetry_event,
+        [:stripe, :webhook, :start],
+        %{monotonic_time: _},
+        %{telemetry_span_context: _}
+      })
+
+      assert_received({
+        :telemetry_event,
+        [:stripe, :webhook, :stop],
+        %{monotonic_time: _, duration: _},
+        %{handler_status: :error, telemetry_span_context: _}
+      })
+    end
+
+    test "emits :start, :stop telemetry events on success", %{conn: conn, test: test} do
+      :telemetry.attach_many(
+        "#{test}",
+        [[:stripe, :webhook, :start], [:stripe, :webhook, :stop]],
+        &__MODULE__.telemetry_handler_fn/4,
+        nil
+      )
+
+      WebhookPlug.call(conn, @opts)
+
+      assert_received({
+        :telemetry_event,
+        [:stripe, :webhook, :start],
+        %{monotonic_time: _},
+        %{telemetry_span_context: _}
+      })
+
+      assert_received({
+        :telemetry_event,
+        [:stripe, :webhook, :stop],
+        %{monotonic_time: _, duration: _},
+        %{handler_status: :ok, event: "customer.updated", telemetry_span_context: _}
+      })
     end
   end
 end

--- a/test/support/stripe_case.ex
+++ b/test/support/stripe_case.ex
@@ -6,31 +6,33 @@ defmodule Stripe.StripeCase do
   use ExUnit.CaseTemplate
 
   def assert_stripe_requested(expected_method, path, extra \\ []) do
-    expected_params = Keyword.get(extra, :query, %{})
-    expected_path = URI.parse(path).path
+    expected_params = normalize_query(Keyword.get(extra, :query, %{}))
+    expected_uri = URI.parse(stripe_base_url() <> path)
     expected_body = Keyword.get(extra, :body)
     expected_headers = Keyword.get(extra, :headers)
 
     assert_received({method, url, headers, body, _})
 
     actual_uri = URI.parse(url)
-
-    actual_query_params =
-      actual_uri.query
-      |> to_string()
-      |> URI.query_decoder()
-      |> Enum.into(%{})
-
-    Enum.each(expected_params, fn {key, value} ->
-      actual_val = Map.get(actual_query_params, to_string(key))
-      assert actual_val == to_string(value)
-    end)
+    actual_params = normalize_query(actual_uri.query || "")
 
     assert expected_method == method
-    assert expected_path == actual_uri.path
+    assert expected_uri.scheme == actual_uri.scheme
+    assert expected_uri.host == actual_uri.host
+    assert expected_uri.port == actual_uri.port
+    assert expected_uri.path == actual_uri.path
+    assert expected_params == actual_params
 
     assert_stripe_request_body(expected_body, body)
     assert_stripe_request_headers(expected_headers, headers)
+  end
+
+  defp normalize_query(query) when is_binary(query) do
+    query |> URI.query_decoder() |> Enum.into(%{})
+  end
+
+  defp normalize_query(query) when is_map(query) or is_list(query) do
+    Map.new(query, fn {k, v} -> {to_string(k), to_string(v)} end)
   end
 
   def get_stripe_request_headers do

--- a/test/support/stripe_case.ex
+++ b/test/support/stripe_case.ex
@@ -6,14 +6,28 @@ defmodule Stripe.StripeCase do
   use ExUnit.CaseTemplate
 
   def assert_stripe_requested(expected_method, path, extra \\ []) do
-    expected_url = build_url(path, Keyword.get(extra, :query))
+    expected_params = Keyword.get(extra, :query, %{})
+    expected_path = URI.parse(path).path
     expected_body = Keyword.get(extra, :body)
     expected_headers = Keyword.get(extra, :headers)
 
     assert_received({method, url, headers, body, _})
 
+    actual_uri = URI.parse(url)
+
+    actual_query_params =
+      actual_uri.query
+      |> to_string()
+      |> URI.query_decoder()
+      |> Enum.into(%{})
+
+    Enum.each(expected_params, fn {key, value} ->
+      actual_val = Map.get(actual_query_params, to_string(key))
+      assert actual_val == to_string(value)
+    end)
+
     assert expected_method == method
-    assert expected_url == url
+    assert expected_path == actual_uri.path
 
     assert_stripe_request_body(expected_body, body)
     assert_stripe_request_headers(expected_headers, headers)
@@ -49,14 +63,6 @@ defmodule Stripe.StripeCase do
 
   defp assert_stripe_request_body(expected_body, body) do
     assert body == Stripe.URI.encode_query(expected_body)
-  end
-
-  defp build_url(path, nil) do
-    stripe_base_url() <> path
-  end
-
-  defp build_url(path, query_params) do
-    stripe_base_url() <> path <> "?" <> URI.encode_query(query_params)
   end
 
   defmodule HackneyMock do


### PR DESCRIPTION
## Summary

This incorporates the work from abandoned PR #833 by @robuye, incorporating the outstanding reviewer feedback from @yordis.

- **API telemetry**: `stripe.request.{start,stop,exception}` events now carry structured metadata — `http_method`, `http_url` (query params stripped to avoid leaking sensitive data like emails), `http_status_code`, `http_retry_count`, `stripe_api_endpoint`, and `stripe_api_version`
- **Webhook telemetry**: `stripe.webhook.{start,stop,exception}` events now carry `event` (the Stripe event type, e.g. `"customer.updated"`) and `handler_status` (`:ok`/`:error`), enabling RED-method monitoring per event type out of the box
- **Flaky test fix**: `assert_stripe_requested` now compares query params as a set (order-independent) rather than doing a full URL string comparison

## Outstanding feedback addressed

- Field names aligned with OTEL conventions (`http_method`, `http_url`, `http_status_code`, `http_retry_count`)
- `stripe_api_endpoint` kept for ergonomic out-of-the-box experience (can be derived from `http_url` by processors)
- `http_url` strips query params to protect sensitive data (e.g. customer emails in search queries) while remaining a parseable string

## Example usage

```elixir
# In PhoenixLiveDashboard telemetry.ex
summary("stripe.request.stop.duration",
  tags: [:stripe_api_endpoint, :http_status_code],
  unit: {:native, :millisecond}
),
summary("stripe.webhook.stop.duration",
  tags: [:event],
  unit: {:native, :millisecond}
)
```

## Test plan

- [x] All existing webhook plug tests pass
- [x] New telemetry tests for webhook (exception, soft failure, success) pass locally
- [x] New telemetry test for API requests passes in CI (requires stripe-mock service)
- [x] `mix format --check-formatted` passes
- [x] `mix credo --strict` passes with no issues