### PR TITLE
chore: update README badges to reference main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An Elixir library for working with [Stripe](https://stripe.com/).
 
 ## 2.x.x status
 
-[![Hex Docs](https://img.shields.io/badge/hex-docs-9768d1.svg)](https://hexdocs.pm/stripity_stripe) [![Inline docs](http://inch-ci.org/github/beam-community/stripity_stripe.svg?branch=master)](http://inch-ci.org/github/beam-community/stripity_stripe?branch=master) [![Coverage Status](https://coveralls.io/repos/github/beam-community/stripity_stripe/badge.svg?branch=master)](https://coveralls.io/github/beam-community/stripity_stripe?branch=master)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-9768d1.svg)](https://hexdocs.pm/stripity_stripe) [![Inline docs](http://inch-ci.org/github/beam-community/stripity_stripe.svg?branch=main)](http://inch-ci.org/github/beam-community/stripity_stripe?branch=main) [![Coverage Status](https://coveralls.io/repos/github/beam-community/stripity_stripe/badge.svg?branch=main)](https://coveralls.io/github/beam-community/stripity_stripe?branch=main)
 
 # Which version should I use?
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An Elixir library for working with [Stripe](https://stripe.com/).
 
 ## 2.x.x status
 
-[![Hex Docs](https://img.shields.io/badge/hex-docs-9768d1.svg)](https://hexdocs.pm/stripity_stripe) [![Inline docs](http://inch-ci.org/github/beam-community/stripity_stripe.svg?branch=main)](http://inch-ci.org/github/beam-community/stripity_stripe?branch=main) [![Coverage Status](https://coveralls.io/repos/github/beam-community/stripity_stripe/badge.svg?branch=main)](https://coveralls.io/github/beam-community/stripity_stripe?branch=main)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-9768d1.svg)](https://hexdocs.pm/stripity_stripe) [![Inline docs](https://inch-ci.org/github/beam-community/stripity_stripe.svg?branch=main)](https://inch-ci.org/github/beam-community/stripity_stripe?branch=main) [![Coverage Status](https://coveralls.io/repos/github/beam-community/stripity_stripe/badge.svg?branch=main)](https://coveralls.io/github/beam-community/stripity_stripe?branch=main)
 
 # Which version should I use?
 


### PR DESCRIPTION
## Summary

- Updates the `inch-ci` (inline docs) and Coveralls (coverage) badge URLs in the README to use `branch=main` instead of `branch=master`, matching the repository's actual default branch name.

## Test Steps

1. View the rendered README on the PR or after merge — the badges should load correctly and point to `main` branch data.
2. Confirm no other badge or CI references to `master` were inadvertently affected (the `master` entry in the version history table and the old `code-corps/stripity-stripe` repo link were intentionally left unchanged).

## Checklist

- [x] Tests added/updated — N/A (docs-only change)
- [x] Documentation updated