### PR TITLE
fix: use post-read_body conn in WebhookPlug error responses

### DIFF
--- a/lib/stripe/webhook_plug.ex
+++ b/lib/stripe/webhook_plug.ex
@@ -132,12 +132,9 @@ if Code.ensure_loaded?(Plug) do
       secret = parse_secret!(secret)
 
       with [signature] <- get_req_header(conn, "stripe-signature"),
-           {:ok, payload, conn} <- Conn.read_body(conn),
-           {:ok, %Stripe.Event{} = event} <- construct_event(payload, signature, secret, opts),
-           :ok <- handle_event!(handler, event) do
-        halt(send_resp(conn, 200, "Webhook received."))
+           {:ok, payload, conn} <- Conn.read_body(conn) do
+        process_event(conn, payload, signature, secret, handler, opts)
       else
-        {:handle_error, reason} -> halt(send_resp(conn, 400, reason))
         _ -> halt(send_resp(conn, 400, "Bad request."))
       end
     end
@@ -149,6 +146,20 @@ if Code.ensure_loaded?(Plug) do
 
     @impl Plug
     def call(conn, _), do: conn
+
+    # Body has been read; `conn` here is the post-`read_body` conn passed as a
+    # parameter, so it stays in scope for both the success and error branches.
+    # Sending the response on the pre-`read_body` conn confuses Bandit's
+    # connection state on keep-alive HTTP/1.1 and can corrupt the next request.
+    defp process_event(conn, payload, signature, secret, handler, opts) do
+      with {:ok, %Stripe.Event{} = event} <- construct_event(payload, signature, secret, opts),
+           :ok <- handle_event!(handler, event) do
+        halt(send_resp(conn, 200, "Webhook received."))
+      else
+        {:handle_error, reason} -> halt(send_resp(conn, 400, reason))
+        _ -> halt(send_resp(conn, 400, "Bad request."))
+      end
+    end
 
     defp construct_event(payload, signature, secret, %{tolerance: tolerance}) do
       Stripe.Webhook.construct_event(payload, signature, secret, tolerance)


### PR DESCRIPTION
## Summary

Properly fixes issue #855 (Bandit.HTTPError corrupting subsequent webhook requests). PR #893 attempted this fix but was a no-op due to how `with`/`else` scoping works in Elixir.

### The bug PR #893 missed

`with`/`else` captures the outer lexical scope at the point the `with` begins — variables rebound inside generators are visible only in the `do` block, **not** in `else`:

```elixir
foo = 1
with foo <- 2,
     false <- true do
  foo          # => 2
else
  _ -> foo     # => 1 (outer scope!)
end
```

Applied to the previous code, `Conn.read_body(conn)` rebound `conn` inside the `with` chain, but every `else` branch was still sending the response on the **pre-`read_body`** conn.

### Why that breaks Bandit

When `send_resp` runs on a stale conn, Bandit thinks the request body hasn't been consumed and drains `Content-Length` bytes from the socket as part of sending the response. Stripe sends webhooks over HTTP/1.1 with keep-alive, so those drained bytes are actually the start of the *next* request — corrupting its request line and producing:

```
Bandit.HTTPError: Request line HTTP error: ",\n"
```

This explains why:
- Issue only reproduces with Bandit (Cowboy handles connection state differently)
- Only manifests on error paths (success path used the correct rebound conn from the `do` block)
- Goes away when handlers return only `:ok`
- Is intermittent — depends on Stripe reusing the keep-alive connection quickly

Credit to @maltoe who [diagnosed this](https://github.com/beam-community/stripity-stripe/issues/855#issuecomment-3772192618) and [explained why #893 didn't fix it](https://github.com/beam-community/stripity-stripe/pull/893#issuecomment-4359332522).

### The fix

Extract the post-`read_body` work into a private `process_event/6` helper. Function parameters are not `with` rebindings, so the inner `with`'s `else` branches see the post-`read_body` conn correctly through the parameter. Original ordering is preserved: signature header is checked **before** the body is read, so unauthenticated requests don't trigger a body read.

| Failure point | `else` branch's `conn` | Correct? |
|---|---|---|
| No `stripe-signature` header | Original conn (body never read) | ✓ |
| `read_body` fails | Original conn (read failed) | ✓ |
| Bad signature / `construct_event` fails | Post-`read_body` conn (function param) | ✓ |
| Handler error | Post-`read_body` conn (function param) | ✓ |

## Test plan

- [x] `mix test test/stripe/webhook_plug_test.exs` — all 12 tests pass
- [ ] Manual reproduction with Bandit: send an invalid-signature webhook immediately followed by a valid one on the same keep-alive connection; with the fix, the second request should not produce `Bandit.HTTPError`

## Notes

The existing test suite uses `Plug.Test.conn/3` (in-memory adapter), which doesn't model conn state the way Bandit does, so it can't catch this bug. Tests passing is necessary but not sufficient — the fix is structural. Marking as draft to discuss whether we want to add an integration test against a real Bandit endpoint.