### PR TITLE
docs: add markdown formatter to docs output

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -86,7 +86,7 @@ defmodule Stripe.Mixfile do
       main: "readme",
       source_url: @source_url,
       source_ref: "v#{@version}",
-      formatters: ["html"],
+      formatters: ["html", "markdown"],
       groups_for_modules: groups_for_modules(),
       nest_modules_by_prefix: nest_modules_by_prefix()
     ]


### PR DESCRIPTION
ex_doc v0.40.0 added a Markdown formatter and generates `llms.txt` by default. Stripity Stripe pins an explicit `formatters:` list, so it does not inherit that default.

This adds only `"markdown"` to the existing list. HTML output is unchanged, and no other formatter is added or removed.

After the next docs publish, `hexdocs.pm/stripity_stripe/llms.txt` will resolve and individual pages will be available as Markdown.

Verified with the committed lockfile:
- `mix docs` (emits `doc/llms.txt` and Markdown pages)
- `mix format --check-formatted`
- `mix credo --strict`
- `mix deps.unlock --check-unused`
- `mix compile --warnings-as-errors`
- `mix dialyzer --format github`
- `mix test` (364 tests, 0 failures; 4 excluded)

This PR was generated from [Elixir's retrieval gap is a rollout problem, not an access problem](https://phxagents.dev/research/elixir-retrieval-gap/).

— Oliver’s AMP